### PR TITLE
Extra mathematical description of discrete delay distributions

### DIFF
--- a/model/equations.md
+++ b/model/equations.md
@@ -10,7 +10,7 @@ Eventually, it should incorporate information about the software implementation 
     - [Latent processes for reproductive number](#latent-processes-for-reproductive-number)
     - [Generation interval and delay to reporting time of reference](#generation-interval-and-delay-to-reporting-time-of-reference)
       - [Interval censoring in days with uniform primary event time and right truncation](#interval-censoring-in-days-with-uniform-primary-event-time-and-right-truncation)
-      - [Left truncation for the generation interval](#left-truncation-for-the-generation interval)
+      - [Left truncation for the generation interval](#left-truncation-for-the-generation-interval)
       - [Reporting delay between the time of reference and the time of report](#reporting-delay-between-the-time-of-reference-and-the-time-of-report)
   - [Signals](#signals)
     - [Hospitalizations](#hospitalizations)

--- a/model/equations.md
+++ b/model/equations.md
@@ -99,9 +99,9 @@ Where $F_{T+U}$ is the cumulative probability function of the delay $T$ with den
 
 In applied modelling we need $p_d$ to be finite length, which we do by conditioning $T\leq T_{max}$ for some value of $T_{max}$, this is commonly call _right truncation_ of the distribution. The right truncated PMF we use in modelling given a continuous distribution for $S-P$ and $T_{max}$ is:
 
-$$
-p_d(\tau) = {\mathbb{P}(T = \tau) \over \sum_{\tau' = 0}^{T_{max}} \mathbb{P}(T = \tau')} \qquad \forall \tau = 0, \dots, T_{max}.
-$$
+```math
+p_d(\tau) = \mathbb{P}(T = \tau) \Big/ \sum_{\tau' = 0}^{T_{max}} \mathbb{P}(T = \tau') \qquad \forall \tau = 0, \dots, T_{max}.
+```
 
 Calculating $F_{T+U}$ for any analytical distribution and value of $\tau = 0, 1, 2,...$ is a _single integral_ which has stable numerical quadrature properties. See [here](https://github.com/CDCgov/Rt-without-renewal/blob/401e028600cecebc76682023eb215d31ead6326d/EpiAware/src/EpiAwareUtils/censored_pmf.jl#L63C1-L75C4) for an example implementation.
 
@@ -114,7 +114,7 @@ The reason for this is that if we allow zero delay infections, then consistently
 For the discretised generation interval the pmf vector is,
 
 $$
-p_d(\tau) = {\mathbb{P}(T = \tau) \over \sum_{\tau' = 1}^{T_{max}} \mathbb{P}(T = \tau')} \qquad \forall \tau = 1, \dots, T_{max}.
+p_d(\tau) = \mathbb{P}(T = \tau) \Big/ \sum_{\tau' = 1}^{T_{max}} \mathbb{P}(T = \tau') \qquad \forall \tau = 1, \dots, T_{max}.
 $$
 
 ### Reporting delay between the time of reference and the time of report

--- a/model/equations.md
+++ b/model/equations.md
@@ -9,7 +9,9 @@ Eventually, it should incorporate information about the software implementation 
     - [Infections](#infections)
     - [Latent processes for reproductive number](#latent-processes-for-reproductive-number)
     - [Generation interval and delay to reporting time of reference](#generation-interval-and-delay-to-reporting-time-of-reference)
-    - [Reporting delay between the time of reference and the time of report](#reporting-delay-between-the-time-of-reference-and-the-time-of-report)
+      - [Interval censoring in days with uniform primary event time and right truncation](#interval-censoring-in-days-with-uniform-primary-event-time-and-right-truncation)
+      - [Left truncation for the generation interval](#left-truncation-for-the-generation interval)
+      - [Reporting delay between the time of reference and the time of report](#reporting-delay-between-the-time-of-reference-and-the-time-of-report)
   - [Signals](#signals)
     - [Hospitalizations](#hospitalizations)
     - [Wastewater](#wastewater)
@@ -68,7 +70,7 @@ Apart from user defined probability mass functions (PMFs) as in [EpiSewer](https
 
 [^1]: [Park, SW, et al *Medrxiv* 2024](https://www.medrxiv.org/content/10.1101/2024.01.12.24301247v1)
 
-### Interval censoring in days with uniform primary event time and right truncation
+#### Interval censoring in days with uniform primary event time and right truncation
 
 Most of our use-cases will use double censoring of events into days; that is both primary and secondary events are censored onto a day. In a slight abuse of notation, we can treat $s,t$ as determining days *and* the continuous time earliest time point in a day. Let the continuous delay distribution have a density function $f$. Then, as per Park *et al*, the probability that the secondary event time $S$ occurs in day $t$ (i.e. $S \in [t, t+1)$), given that the primary event time $P$ occurred in day $s$ (i.e. $P\in[s, s)$) is,
 
@@ -105,7 +107,7 @@ p_d(\tau) = \mathbb{P}(T = \tau) \Big/ \sum_{\tau' = 0}^{T_{max}} \mathbb{P}(T =
 
 Calculating $F_{T+U}$ for any analytical distribution and value of $\tau = 0, 1, 2,...$ is a _single integral_ which has stable numerical quadrature properties. See [here](https://github.com/CDCgov/Rt-without-renewal/blob/401e028600cecebc76682023eb215d31ead6326d/EpiAware/src/EpiAwareUtils/censored_pmf.jl#L63C1-L75C4) for an example implementation.
 
-### Left truncation for the generation interval
+#### Left truncation for the generation interval
 
 It is typical to also condition on the delay between infector and infectee being at least one day; that is if $T$ models the generation interval delay then $T>0$.
 
@@ -117,7 +119,7 @@ $$
 p_d(\tau) = \mathbb{P}(T = \tau) \Big/ \sum_{\tau' = 1}^{T_{max}} \mathbb{P}(T = \tau') \qquad \forall \tau = 1, \dots, T_{max}.
 $$
 
-### Reporting delay between the time of reference and the time of report
+#### Reporting delay between the time of reference and the time of report
 
 The reporting delay is the random time between the time of reference of a case and the time of report when the data of that case becomes available to analysts (see [Epinowcast definition](https://package.epinowcast.org/dev/articles/model.html#decomposition-into-expected-final-notifications-and-report-delay-components)).
 

--- a/model/equations.md
+++ b/model/equations.md
@@ -70,7 +70,7 @@ Apart from user defined probability mass functions (PMFs) as in [EpiSewer](https
 
 ### Interval censoring in days with uniform primary event time and right truncation
 
-Most of our use-cases will use double censoring of events into days; that is both primary and secondary events are censored onto a day. In a slight abuse of notation, we can treat $s,t$ as determining days *and* the continuous time earliest time point in a day. Let the continuous delay distribution have a density function $f$. Then, as per Park *et al*, the probability that the secondary event time $S$ occurs in day $t$ (i.e. \$ S \\in \[t, t+1)\$), given that the primary event time $P$ occurred in day $s$ (i.e. $P\in[s, s)$) is,
+Most of our use-cases will use double censoring of events into days; that is both primary and secondary events are censored onto a day. In a slight abuse of notation, we can treat $s,t$ as determining days *and* the continuous time earliest time point in a day. Let the continuous delay distribution have a density function $f$. Then, as per Park *et al*, the probability that the secondary event time $S$ occurs in day $t$ (i.e. $S \in [t, t+1)$), given that the primary event time $P$ occurred in day $s$ (i.e. $P\in[s, s)$) is,
 
 $$
 \mathbb{P}(S = t| P = s) = \int_s^{s+1} \int_t^{t+1} g_P(x) f(y-x) \text{d}y \text{d}x.


### PR DESCRIPTION
Add to [equations.md](https://github.com/CDCgov/multisignal-epi-inference/blob/43-mathematical-description/model/equations.md) to increase amount of detail on interval censoring and truncation for delay distributions.

Closes #43 
