### PR TITLE
Refactoring sample from dicts to named arguments + **kwargs

### DIFF
--- a/model/docs/getting-started.md
+++ b/model/docs/getting-started.md
@@ -89,10 +89,7 @@ rt_proc = RtRandomWalkProcess()
 latent_infections = Infections()
 
 # (5) The observed infections process (with mean at the latent infections)
-observed_infections = PoissonObservation(
-    rate_varname   = 'latent',
-    counts_varname = 'observed_infections',
-    )
+observed_infections = PoissonObservation()
 ```
 
 With these five pieces, we can build the basic renewal model:
@@ -136,7 +133,7 @@ function of `RtInfectionsRenewalModel`:
 ``` python
 np.random.seed(223)
 with npro.handlers.seed(rng_seed = np.random.randint(1, 60)):
-    sim_data = model1.sample(constants = dict(n_timepoints=30))
+    sim_data = model1.sample(n_timepoints=30)
 
 sim_data
 ```
@@ -187,13 +184,11 @@ To fit the model, we can use the `run()` method of the model
 ``` python
 import jax
 
-model_data = {'n_timepoints': len(sim_data[1])-1}
-
 model1.run(
     num_warmup=2000,
     num_samples=1000,
-    random_variables=dict(observed_infections=sim_data.observed),
-    constants=model_data,
+    observed_infections=sim_data.observed,
+    n_timepoints = len(sim_data[1])-1,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
     )

--- a/model/docs/getting-started.qmd
+++ b/model/docs/getting-started.qmd
@@ -67,10 +67,7 @@ rt_proc = RtRandomWalkProcess()
 latent_infections = Infections()
 
 # (5) The observed infections process (with mean at the latent infections)
-observed_infections = PoissonObservation(
-    rate_varname   = 'latent',
-    counts_varname = 'observed_infections',
-    )
+observed_infections = PoissonObservation()
 ```
 
 With these five pieces, we can build the basic renewal model:
@@ -112,7 +109,7 @@ Using `numpyro`, we can simulate data using the `sample()` member function of `R
 #| label: simulate
 np.random.seed(223)
 with npro.handlers.seed(rng_seed = np.random.randint(1, 60)):
-    sim_data = model1.sample(constants = dict(n_timepoints=30))
+    sim_data = model1.sample(n_timepoints=30)
 
 sim_data
 ```
@@ -147,13 +144,11 @@ To fit the model, we can use the `run()` method of the model `RtInfectionsRenewa
 #| label: model-fit
 import jax
 
-model_data = {'n_timepoints': len(sim_data[1])-1}
-
 model1.run(
     num_warmup=2000,
     num_samples=1000,
-    random_variables=dict(observed_infections=sim_data.observed),
-    constants=model_data,
+    observed_infections=sim_data.observed,
+    n_timepoints = len(sim_data[1])-1,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
     )

--- a/model/docs/pyrenew_demo.md
+++ b/model/docs/pyrenew_demo.md
@@ -21,8 +21,6 @@ import numpyro.distributions as dist
 from pyrenew.process import SimpleRandomWalkProcess
 ```
 
-    An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
-
 ``` python
 np.random.seed(3312)
 q = SimpleRandomWalkProcess(dist.Normal(0, 0.001))
@@ -71,10 +69,7 @@ latent_hospitalizations = HospitalAdmissions(
     )
 
 # And observation process for the hospitalizations
-observed_hospitalizations = PoissonObservation(
-    rate_varname='latent',
-    counts_varname='observed_hospitalizations',
-    )
+observed_hospitalizations = PoissonObservation()
 
 # And a random walk process (it could be deterministic using
 # pyrenew.process.DeterministicProcess())
@@ -93,7 +88,7 @@ hospmodel = HospitalizationsModel(
 
 ``` python
 with seed(rng_seed=np.random.randint(1, 60)):
-    x = hospmodel.sample(constants=dict(n_timepoints=30))
+    x = hospmodel.sample(n_timepoints=30)
 x
 ```
 
@@ -130,15 +125,12 @@ for axis in ax[:-1]:
 ![](pyrenew_demo_files/figure-commonmark/fig-hosp-output-1.png)
 
 ``` python
-sim_dat={"observed_hospitalizations": x.sampled}
-constants = {"n_timepoints":len(x.sampled)-1}
-
 # from numpyro.infer import MCMC, NUTS
 hospmodel.run(
     num_warmup=1000,
     num_samples=1000,
-    random_variables=sim_dat,
-    constants=constants,
+    observed_hospitalizations=x.sampled,
+    n_timepoints = len(x.sampled)-1,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
     )

--- a/model/docs/pyrenew_demo.qmd
+++ b/model/docs/pyrenew_demo.qmd
@@ -73,10 +73,7 @@ latent_hospitalizations = HospitalAdmissions(
     )
 
 # And observation process for the hospitalizations
-observed_hospitalizations = PoissonObservation(
-    rate_varname='latent',
-    counts_varname='observed_hospitalizations',
-    )
+observed_hospitalizations = PoissonObservation()
 
 # And a random walk process (it could be deterministic using
 # pyrenew.process.DeterministicProcess())
@@ -96,7 +93,7 @@ hospmodel = HospitalizationsModel(
 
 ```{python}
 with seed(rng_seed=np.random.randint(1, 60)):
-    x = hospmodel.sample(constants=dict(n_timepoints=30))
+    x = hospmodel.sample(n_timepoints=30)
 x
 ```
 
@@ -113,15 +110,12 @@ for axis in ax[:-1]:
 ```
 
 ```{python}
-sim_dat={"observed_hospitalizations": x.sampled}
-constants = {"n_timepoints":len(x.sampled)-1}
-
 # from numpyro.infer import MCMC, NUTS
 hospmodel.run(
     num_warmup=1000,
     num_samples=1000,
-    random_variables=sim_dat,
-    constants=constants,
+    observed_hospitalizations=x.sampled,
+    n_timepoints = len(x.sampled)-1,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
     )

--- a/model/src/pyrenew/deterministic/deterministic.py
+++ b/model/src/pyrenew/deterministic/deterministic.py
@@ -47,7 +47,7 @@ class DeterministicVariable(RandomVariable):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict, optional
             Ignored.
 
         Returns

--- a/model/src/pyrenew/deterministic/deterministic.py
+++ b/model/src/pyrenew/deterministic/deterministic.py
@@ -41,18 +41,14 @@ class DeterministicVariable(RandomVariable):
 
     def sample(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
         """Retrieve the value of the deterministic Rv
 
         Parameters
         ----------
-
-        random_variables : dict
-            Ignored. Default None.
-        constants : dict
-            Ignored. Default None.
+        kwargs : dict
+            Ignored.
 
         Returns
         -------

--- a/model/src/pyrenew/deterministic/deterministicpmf.py
+++ b/model/src/pyrenew/deterministic/deterministicpmf.py
@@ -59,7 +59,8 @@ class DeterministicPMF(RandomVariable):
         Parameters
         ----------
         **kwargs : dict, optional
-            Arguments to pass to the sample method.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Returns
         -------

--- a/model/src/pyrenew/deterministic/deterministicpmf.py
+++ b/model/src/pyrenew/deterministic/deterministicpmf.py
@@ -52,18 +52,14 @@ class DeterministicPMF(RandomVariable):
 
     def sample(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
         """Retrieves the deterministic PMF
 
         Parameters
         ----------
-
-        random_variables : dict
-            Ignored. Default None.
-        constants : dict
-            Ignored. Default None.
+        kwargs : dict
+            Arguments to pass to the sample method.
 
         Returns
         -------
@@ -71,7 +67,4 @@ class DeterministicPMF(RandomVariable):
             Containing the stored values during construction.
         """
 
-        return self.basevar.sample(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        return self.basevar.sample(**kwargs)

--- a/model/src/pyrenew/deterministic/deterministicpmf.py
+++ b/model/src/pyrenew/deterministic/deterministicpmf.py
@@ -58,7 +58,7 @@ class DeterministicPMF(RandomVariable):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict, optional
             Arguments to pass to the sample method.
 
         Returns

--- a/model/src/pyrenew/latent/hospitaladmissions.py
+++ b/model/src/pyrenew/latent/hospitaladmissions.py
@@ -39,8 +39,7 @@ class InfectHospRate(RandomVariable):
             Prior distribution of the IHR, by default
             dist.LogNormal(jnp.log(0.05), 0.05)
         varname : str, optional
-            Name of the random_variable that may hold observed IHR, by default
-            "IHR"
+            Name of the random variable in the model, by default "IHR."
 
         Returns
         -------
@@ -61,8 +60,8 @@ class InfectHospRate(RandomVariable):
     def sample(self, **kwargs) -> InfectHospRateSample:
         return InfectHospRateSample(
             npro.sample(
-                "IHR",
-                self.dist,
+                name=self.varname,
+                fn=self.dist,
             )
         )
 
@@ -103,8 +102,8 @@ class HospitalAdmissions(RandomVariable):
         infection_to_admission_interval: RandomVariable,
         infect_hosp_rate_dist: RandomVariable,
         hospitalizations_predicted_varname: str = "predicted_hospitalizations",
-        weekday_effect_dist: RandomVariable = DeterministicVariable((1,)),
-        hosp_report_prob_dist: RandomVariable = DeterministicVariable((1,)),
+        weekday_effect_dist: RandomVariable = None,
+        hosp_report_prob_dist: RandomVariable = None,
     ) -> None:
         """Default constructor
 
@@ -128,6 +127,12 @@ class HospitalAdmissions(RandomVariable):
         -------
         None
         """
+
+        if weekday_effect_dist is None:
+            weekday_effect_dist = DeterministicVariable((1,))
+        if hosp_report_prob_dist is None:
+            hosp_report_prob_dist = DeterministicVariable((1,))
+
         HospitalAdmissions.validate(
             infect_hosp_rate_dist,
             weekday_effect_dist,
@@ -167,7 +172,8 @@ class HospitalAdmissions(RandomVariable):
         latent : ArrayLike
             Latent infections.
         **kwargs : dict, optional
-            Keyword arguments passed to the sampling methods.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Returns
         -------

--- a/model/src/pyrenew/latent/hospitaladmissions.py
+++ b/model/src/pyrenew/latent/hospitaladmissions.py
@@ -166,7 +166,7 @@ class HospitalAdmissions(RandomVariable):
         ----------
         latent : ArrayLike
             Latent infections.
-        kwargs : dict
+        **kwargs : dict, optional
             Keyword arguments passed to the sampling methods.
 
         Returns

--- a/model/src/pyrenew/latent/i0.py
+++ b/model/src/pyrenew/latent/i0.py
@@ -58,7 +58,7 @@ class Infections0(RandomVariable):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict, optional
             Ignored
 
         Returns

--- a/model/src/pyrenew/latent/i0.py
+++ b/model/src/pyrenew/latent/i0.py
@@ -52,17 +52,14 @@ class Infections0(RandomVariable):
 
     def sample(
         self,
-        random_variables: dict,
-        constants: dict,
+        **kwargs,
     ) -> tuple:
         """Sample the initial infections.
 
         Parameters
         ----------
-        random_variables : dict
-            Dictionary of random variables.
-        constants : dict
-            Dictionary of constants.
+        kwargs : dict
+            Ignored
 
         Returns
         -------

--- a/model/src/pyrenew/latent/infections.py
+++ b/model/src/pyrenew/latent/infections.py
@@ -27,8 +27,7 @@ class Infections(RandomVariable):
         Parameters
         ----------
         infections_mean_varname : str.
-            Name of the element in `random_variables` that will hold the value
-            of mean 'infections'.
+            Name to be assigned to the deterministic variable in the model.
 
         Returns
         -------

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -91,26 +91,16 @@ class RandomVariable(metaclass=ABCMeta):
     @abstractmethod
     def sample(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
         """Sample method of the process
 
-        The method design in the class should have two dictionaries:
-        `random_variables` and `constants`.
-
-        - `randon_variables`: This dictionary contains any data that sample
-          function may pass to `numpyro.sample(obs=...)`.
-
-        - `constants`: Contains any data that the sample function does not pass
-          to `numpyro.sample(obs=...)`.
+        The method design in the class should have at least kwargs.
 
         Parameters
         ----------
-        random_variables : dict, optional
-            Dictionary of random variables, defaults to None
-        constants : dict, optional
-            Dictionary of constants
+        kwargs : dict
+            Dictionary of arguments passed to the sample function.
 
         Returns
         -------
@@ -141,8 +131,7 @@ class Model(metaclass=ABCMeta):
     @abstractmethod
     def sample(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
         pass
 

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -100,7 +100,8 @@ class RandomVariable(metaclass=ABCMeta):
         Parameters
         ----------
         **kwargs : dict, optional
-            Dictionary of arguments passed to the sample function.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Notes
         -----
@@ -147,7 +148,8 @@ class Model(metaclass=ABCMeta):
         Parameters
         ----------
         **kwargs : dict, optional
-            Dictionary of arguments passed to the sample function.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Notes
         -----

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -99,8 +99,13 @@ class RandomVariable(metaclass=ABCMeta):
 
         Parameters
         ----------
-        kwargs : dict
+        **kwargs : dict, optional
             Dictionary of arguments passed to the sample function.
+
+        Notes
+        -----
+        <description of how the kwargs documented above does not cover all
+        kwargs (in some instances)>
 
         Returns
         -------
@@ -115,6 +120,8 @@ class RandomVariable(metaclass=ABCMeta):
 
 
 class Model(metaclass=ABCMeta):
+    """Abstract base class for models"""
+
     # Since initialized in none, values not shared across instances
     kernel = None
     mcmc = None
@@ -133,6 +140,24 @@ class Model(metaclass=ABCMeta):
         self,
         **kwargs,
     ) -> tuple:
+        """Sample method of the model
+
+        The method design in the class should have at least kwargs.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Dictionary of arguments passed to the sample function.
+
+        Notes
+        -----
+        <description of how the kwargs documented above does not cover all
+        kwargs (in some instances)>
+
+        Returns
+        -------
+        tuple
+        """
         pass
 
     def _init_model(

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -193,10 +193,9 @@ class Model(metaclass=ABCMeta):
         num_warmup,
         num_samples,
         rng_key: jax.random.PRNGKey = jax.random.PRNGKey(54),
-        random_variables: dict = None,
-        constants: dict = None,
         nuts_args: dict = None,
         mcmc_args: dict = None,
+        **kwargs,
     ) -> None:
         """Runs the model
 
@@ -212,12 +211,6 @@ class Model(metaclass=ABCMeta):
             None
         """
 
-        if random_variables is None:
-            random_variables = dict()
-
-        if constants is None:
-            constants = dict()
-
         if self.mcmc is None:
             self._init_model(
                 num_warmup=num_warmup,
@@ -226,11 +219,7 @@ class Model(metaclass=ABCMeta):
                 mcmc_args=mcmc_args,
             )
 
-        self.mcmc.run(
-            rng_key=rng_key,
-            random_variables=random_variables,
-            constants=constants,
-        )
+        self.mcmc.run(rng_key=rng_key, **kwargs)
 
         return None
 

--- a/model/src/pyrenew/model/hospitalizations.py
+++ b/model/src/pyrenew/model/hospitalizations.py
@@ -128,7 +128,8 @@ class HospitalizationsModel(Model):
         n_timepoints : int
             Number of timepoints to sample (passed to the basic renewal model).
         **kwargs : dict, optional
-            Keyword arguments passed to the sampling methods.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Returns
         -------

--- a/model/src/pyrenew/model/hospitalizations.py
+++ b/model/src/pyrenew/model/hospitalizations.py
@@ -127,7 +127,7 @@ class HospitalizationsModel(Model):
         ----------
         n_timepoints : int
             Number of timepoints to sample (passed to the basic renewal model).
-        kwargs : dict
+        **kwargs : dict, optional
             Keyword arguments passed to the sampling methods.
 
         Returns

--- a/model/src/pyrenew/model/hospitalizations.py
+++ b/model/src/pyrenew/model/hospitalizations.py
@@ -93,7 +93,7 @@ class HospitalizationsModel(Model):
 
     def sample_hospitalizations_obs(
         self,
-        latent: ArrayLike,
+        predicted: ArrayLike,
         observed_hospitalizations: ArrayLike,
         **kwargs,
     ) -> tuple:
@@ -101,11 +101,10 @@ class HospitalizationsModel(Model):
 
         Parameters
         ----------
-        random_variables : dict
-            A dictionary containing `infections` passed to the specified
-            sampler.
-        constants : dict, optional
-            Possible constants for the model.
+        predicted : ArrayLike
+            Predicted hospitalizations.
+        observed_hospitalizations : ArrayLike
+            Observed hospitalizations.
 
         Returns
         -------
@@ -113,7 +112,7 @@ class HospitalizationsModel(Model):
         """
 
         return self.observed_hospitalizations.sample(
-            mean=latent, obs=observed_hospitalizations, **kwargs
+            predicted=predicted, obs=observed_hospitalizations, **kwargs
         )
 
     def sample(
@@ -155,7 +154,7 @@ class HospitalizationsModel(Model):
 
         # Sampling the hospitalizations
         sampled, *_ = self.sample_hospitalizations_obs(
-            latent=latent,
+            predicted=latent,
             observed_hospitalizations=observed_hospitalizations,
             **kwargs,
         )

--- a/model/src/pyrenew/model/rtinfectionsrenewal.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewal.py
@@ -2,6 +2,7 @@
 
 from collections import namedtuple
 
+from numpy.typing import ArrayLike
 from pyrenew.metaclass import Model, RandomVariable, _assert_sample_and_rtype
 
 # Output class of the RtInfectionsRenewalModel
@@ -26,7 +27,7 @@ class RtInfectionsRenewalModel(Model):
         gen_int: RandomVariable,
         I0: RandomVariable,
         Rt_process: RandomVariable,
-        observed_infections: RandomVariable = None,
+        observed_infections: RandomVariable,
     ) -> None:
         """Default constructor
 
@@ -83,117 +84,86 @@ class RtInfectionsRenewalModel(Model):
 
     def sample_rt(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
-        return self.Rt_process.sample(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        return self.Rt_process.sample(**kwargs)
 
     def sample_gen_int(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
-        return self.gen_int.sample(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        return self.gen_int.sample(**kwargs)
 
     def sample_i0(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
-        return self.i0.sample(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        return self.i0.sample(**kwargs)
 
     def sample_infections_latent(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        **kwargs,
     ) -> tuple:
-        return self.latent_infections.sample(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        return self.latent_infections.sample(**kwargs)
 
     def sample_infections_obs(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        latent: ArrayLike,
+        observed_infections: ArrayLike = None,
+        **kwargs,
     ) -> tuple:
-        if self.observed_infections is None:
-            return (None,)
-
         return self.observed_infections.sample(
-            random_variables=random_variables,
-            constants=constants,
+            mean=latent,
+            obs=observed_infections,
+            **kwargs,
         )
 
     def sample(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        n_timepoints: int,
+        observed_infections: ArrayLike = None,
+        **kwargs,
     ) -> RtInfectionsRenewalSample:
         """Sample from the Basic Renewal Model
 
         Parameters
         ----------
-        random_variables : dict, optional
-            A dictionary containing `infections` and/or `Rt` (optional).
-        constants : dict, optional
-            A dictionary containing `n_timepoints`.
+        n_timepoints : int
+            Number of timepoints to sample.
+        observed_infections : ArrayLike, optional
+            Observed infections.
+        kwargs : dict
+            Keyword arguments passed to the sampling methods.
 
         Returns
         -------
         RtInfectionsRenewalSample
         """
 
-        if random_variables is None:
-            random_variables = dict()
-
-        if constants is None:
-            constants = dict()
-
         # Sampling from Rt (possibly with a given Rt, depending on
         # the Rt_process (RandomVariable) object.)
         Rt, *_ = self.sample_rt(
-            random_variables=random_variables,
-            constants=constants,
+            n_timepoints=n_timepoints,
+            **kwargs,
         )
 
         # Getting the generation interval
-        gen_int, *_ = self.sample_gen_int(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        gen_int, *_ = self.sample_gen_int(**kwargs)
 
         # Sampling initial infections
-        i0, *_ = self.sample_i0(
-            random_variables=random_variables,
-            constants=constants,
-        )
+        i0, *_ = self.sample_i0(**kwargs)
 
         # Sampling from the latent process
         latent, *_ = self.sample_infections_latent(
-            random_variables={
-                **random_variables,
-                **dict(Rt=Rt, gen_int=gen_int, I0=i0),
-            },
-            constants=constants,
+            Rt=Rt,
+            gen_int=gen_int,
+            I0=i0,
+            **kwargs,
         )
 
         # Using the predicted infections to sample from the observation process
         observed, *_ = self.sample_infections_obs(
-            random_variables={
-                **random_variables,
-                **dict(latent=latent),
-            },
-            constants=constants,
+            latent=latent, observed_infections=observed_infections, **kwargs
         )
 
         return RtInfectionsRenewalSample(

--- a/model/src/pyrenew/model/rtinfectionsrenewal.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewal.py
@@ -45,8 +45,7 @@ class RtInfectionsRenewalModel(Model):
             first element is the drawn Rt.
         observed_infections : RandomVariable, optional
             Infections observation process (e.g.,
-            pyrenew.observations.Poisson.) It should receive the sampled Rt
-            via `random_variables`.
+            pyrenew.observations.Poisson.).
 
         Returns
         -------
@@ -133,7 +132,8 @@ class RtInfectionsRenewalModel(Model):
         observed_infections : ArrayLike, optional
             Observed infections.
         **kwargs : dict, optional
-            Keyword arguments passed to the sampling methods.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Returns
         -------

--- a/model/src/pyrenew/model/rtinfectionsrenewal.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewal.py
@@ -108,12 +108,12 @@ class RtInfectionsRenewalModel(Model):
 
     def sample_infections_obs(
         self,
-        latent: ArrayLike,
+        predicted: ArrayLike,
         observed_infections: ArrayLike = None,
         **kwargs,
     ) -> tuple:
         return self.observed_infections.sample(
-            mean=latent,
+            predicted=predicted,
             obs=observed_infections,
             **kwargs,
         )
@@ -163,7 +163,7 @@ class RtInfectionsRenewalModel(Model):
 
         # Using the predicted infections to sample from the observation process
         observed, *_ = self.sample_infections_obs(
-            latent=latent, observed_infections=observed_infections, **kwargs
+            predicted=latent, observed_infections=observed_infections, **kwargs
         )
 
         return RtInfectionsRenewalSample(

--- a/model/src/pyrenew/model/rtinfectionsrenewal.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewal.py
@@ -132,7 +132,7 @@ class RtInfectionsRenewalModel(Model):
             Number of timepoints to sample.
         observed_infections : ArrayLike, optional
             Observed infections.
-        kwargs : dict
+        **kwargs : dict, optional
             Keyword arguments passed to the sampling methods.
 
         Returns

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -16,8 +16,6 @@ class NegativeBinomialObservation(RandomVariable):
         concentration_prior: dist.Distribution | ArrayLike,
         concentration_suffix: str = "_concentration",
         parameter_name="negbinom_rv",
-        mean_varname="mean",
-        counts_varname="counts",
     ) -> None:
         """Default constructor
 
@@ -34,12 +32,6 @@ class NegativeBinomialObservation(RandomVariable):
             Suffix for the numpy variable.
         parameter_name : str, optional
             Name for the numpy variable.
-        mean_varname : str, optional
-            Name of the element in `random_variables` that will hold the rate
-            when calling `PoissonObservation.sample()`.
-        counts_varname: str, optional
-            Name of the element in `random_variables` that will hold the
-            observed count when calling `PoissonObservation.sample()`.
 
         Returns
         -------
@@ -58,23 +50,23 @@ class NegativeBinomialObservation(RandomVariable):
 
         self.parameter_name = parameter_name
         self.concentration_suffix = concentration_suffix
-        self.mean_varname = mean_varname
-        self.counts_varname = counts_varname
 
     def sample(
         self,
-        random_variables: dict,
-        constants: dict = None,
+        mean: ArrayLike,
+        obs: ArrayLike = None,
+        **kwargs,
     ) -> tuple:
         """Sample from the negative binomial distribution
 
         Parameters
         ----------
-        random_variables : dict, optional
-            A dictionary containing the `mean` parameter, and possibly
-            containing `counts`, which is passed to `obs` `numpyro.sample()`.
-        constants : dict, optional
-            Ignored, defaults to dict().
+        mean : ArrayLike
+            Mean parameter of the negative binomial distribution.
+        obs : ArrayLike, optional
+            Observed data, by default None.
+        kwargs : dict
+            Keyword arguments passed to the sampling methods.
 
         Returns
         -------
@@ -84,10 +76,10 @@ class NegativeBinomialObservation(RandomVariable):
             numpyro.sample(
                 self.parameter_name,
                 dist.NegativeBinomial2(
-                    mean=random_variables.get(self.mean_varname),
+                    mean=mean,
                     concentration=self.sample_prior(),
                 ),
-                obs=random_variables.get(self.counts_varname, None),
+                obs=obs,
             ),
         )
 

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -66,7 +66,8 @@ class NegativeBinomialObservation(RandomVariable):
         obs : ArrayLike, optional
             Observed data, by default None.
         **kwargs : dict, optional
-            Keyword arguments passed to the sampling methods.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Returns
         -------

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -65,7 +65,7 @@ class NegativeBinomialObservation(RandomVariable):
             Mean parameter of the negative binomial distribution.
         obs : ArrayLike, optional
             Observed data, by default None.
-        kwargs : dict
+        **kwargs : dict, optional
             Keyword arguments passed to the sampling methods.
 
         Returns

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -53,7 +53,7 @@ class NegativeBinomialObservation(RandomVariable):
 
     def sample(
         self,
-        mean: ArrayLike,
+        predicted: ArrayLike,
         obs: ArrayLike = None,
         **kwargs,
     ) -> tuple:
@@ -61,7 +61,7 @@ class NegativeBinomialObservation(RandomVariable):
 
         Parameters
         ----------
-        mean : ArrayLike
+        predicted : ArrayLike
             Mean parameter of the negative binomial distribution.
         obs : ArrayLike, optional
             Observed data, by default None.
@@ -76,7 +76,7 @@ class NegativeBinomialObservation(RandomVariable):
             numpyro.sample(
                 self.parameter_name,
                 dist.NegativeBinomial2(
-                    mean=mean,
+                    mean=predicted,
                     concentration=self.sample_prior(),
                 ),
                 obs=obs,

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -49,7 +49,7 @@ class PoissonObservation(RandomVariable):
             Rate parameter of the Poisson distribution.
         obs : ArrayLike, optional
             Observed data, by default None.
-        kwargs : dict
+        **kwargs : dict, optional
             Keyword arguments passed to the sampling methods.
 
         Returns

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -37,7 +37,7 @@ class PoissonObservation(RandomVariable):
 
     def sample(
         self,
-        mean: ArrayLike,
+        predicted: ArrayLike,
         obs: ArrayLike = None,
         **kwargs,
     ) -> tuple:
@@ -45,7 +45,7 @@ class PoissonObservation(RandomVariable):
 
         Parameters
         ----------
-        mean : ArrayLike
+        predicted : ArrayLike
             Rate parameter of the Poisson distribution.
         obs : ArrayLike, optional
             Observed data, by default None.
@@ -59,7 +59,7 @@ class PoissonObservation(RandomVariable):
         return (
             numpyro.sample(
                 self.parameter_name,
-                dist.Poisson(rate=mean + self.eps),
+                dist.Poisson(rate=predicted + self.eps),
                 obs=obs,
             ),
         )

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -50,7 +50,8 @@ class PoissonObservation(RandomVariable):
         obs : ArrayLike, optional
             Observed data, by default None.
         **kwargs : dict, optional
-            Keyword arguments passed to the sampling methods.
+            Additional keyword arguments passed through to internal `sample()`
+            calls, if any
 
         Returns
         -------

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -2,6 +2,7 @@
 
 import numpyro
 import numpyro.distributions as dist
+from numpy.typing import ArrayLike
 from pyrenew.metaclass import RandomVariable
 
 
@@ -13,8 +14,6 @@ class PoissonObservation(RandomVariable):
     def __init__(
         self,
         parameter_name: str = "poisson_rv",
-        rate_varname: str = "rate",
-        counts_varname: str = "counts",
         eps: float = 1e-8,
     ) -> None:
         """Default Constructor
@@ -23,12 +22,8 @@ class PoissonObservation(RandomVariable):
         ----------
         parameter_name : str, optional
             Passed to numpyro.sample.
-        rate_varname : str, optional
-            Name of the element in `random_variables` that will hold the rate
-            when calling `PoissonObservation.sample()`.
-        counts_varname : str, optional
-            Name of the element in `random_variables` that will hold the
-            observed count when calling `PoissonObservation.sample()`.
+        eps : float, optional
+            Small value added to the rate parameter to avoid zero values.
 
         Returns
         -------
@@ -36,27 +31,26 @@ class PoissonObservation(RandomVariable):
         """
 
         self.parameter_name = parameter_name
-        self.rate_varname = rate_varname
-        self.counts_varname = counts_varname
         self.eps = eps
 
         return None
 
     def sample(
         self,
-        random_variables: dict,
-        constants: dict = None,
+        mean: ArrayLike,
+        obs: ArrayLike = None,
+        **kwargs,
     ) -> tuple:
         """Sample from the Poisson process
 
         Parameters
         ----------
-        random_variables : dict, optional
-            A dictionary containing the rate parameter passed to
-            `numpyro.distributions.Poisson()`, and possible containing `counts`
-            passed to `obs` in `numpyro.sample()`.
-        constants : dict, optional
-            Ignored.
+        mean : ArrayLike
+            Rate parameter of the Poisson distribution.
+        obs : ArrayLike, optional
+            Observed data, by default None.
+        kwargs : dict
+            Keyword arguments passed to the sampling methods.
 
         Returns
         -------
@@ -65,10 +59,8 @@ class PoissonObservation(RandomVariable):
         return (
             numpyro.sample(
                 self.parameter_name,
-                dist.Poisson(
-                    rate=random_variables.get(self.rate_varname) + self.eps
-                ),
-                obs=random_variables.get(self.counts_varname, None),
+                dist.Poisson(rate=mean + self.eps),
+                obs=obs,
             ),
         )
 

--- a/model/src/pyrenew/process/ar.py
+++ b/model/src/pyrenew/process/ar.py
@@ -57,7 +57,7 @@ class ARProcess(RandomVariable):
             Initial points, if None, then these are sampled.
         name : str, optional
             Name of the parameter passed to numpyro.sample.
-        kwargs : dict
+        **kwargs : dict, optional
             Ignored.
 
         Returns

--- a/model/src/pyrenew/process/ar.py
+++ b/model/src/pyrenew/process/ar.py
@@ -45,6 +45,7 @@ class ARProcess(RandomVariable):
         duration: int,
         inits: ArrayLike = None,
         name: str = "arprocess",
+        **kwargs,
     ) -> tuple:
         """Sample from the AR process
 
@@ -56,6 +57,8 @@ class ARProcess(RandomVariable):
             Initial points, if None, then these are sampled.
         name : str, optional
             Name of the parameter passed to numpyro.sample.
+        kwargs : dict
+            Ignored.
 
         Returns
         -------

--- a/model/src/pyrenew/process/firstdifferencear.py
+++ b/model/src/pyrenew/process/firstdifferencear.py
@@ -53,7 +53,7 @@ class FirstDifferenceARProcess(RandomVariable):
             Passed to ARProcess.sample, by default None.
         name : str, optional
             Passed to ARProcess.sample(), by default "trend_rw"
-        kwargs : dict
+        **kwargs : dict, optional
             Ignored.
 
         Returns

--- a/model/src/pyrenew/process/firstdifferencear.py
+++ b/model/src/pyrenew/process/firstdifferencear.py
@@ -39,6 +39,7 @@ class FirstDifferenceARProcess(RandomVariable):
         init_val: ArrayLike = None,
         init_rate_of_change: ArrayLike = None,
         name: str = "trend_rw",
+        **kwargs,
     ) -> tuple:
         """Sample from the process
 
@@ -52,6 +53,8 @@ class FirstDifferenceARProcess(RandomVariable):
             Passed to ARProcess.sample, by default None.
         name : str, optional
             Passed to ARProcess.sample(), by default "trend_rw"
+        kwargs : dict
+            Ignored.
 
         Returns
         -------

--- a/model/src/pyrenew/process/rtrandomwalk.py
+++ b/model/src/pyrenew/process/rtrandomwalk.py
@@ -51,34 +51,24 @@ class RtRandomWalkProcess(RandomVariable):
 
     def sample(
         self,
-        random_variables: dict = None,
-        constants: dict = None,
+        n_timepoints: int,
+        **kwargs,
     ) -> tuple:
         """Generate samples from the process
 
         Parameters
         ----------
-        random_variables : dict
-            A dictionary containing `Rt0` (optional).
-        constants : dict.
-            A dictionary containing `n_timepoints`.
+        n_timepoints : int
+            Number of timepoints to sample.
+        kwargs : dict
+            Ignored.
 
         Returns
         -------
         tuple
         """
 
-        if random_variables is None:
-            random_variables = dict()
-
-        if constants is None:
-            constants = dict()
-
-        n_timepoints = constants.get("n_timepoints")
-
-        Rt0 = npro.sample(
-            "Rt0", self.Rt0_dist, obs=random_variables.get("Rt0", None)
-        )
+        Rt0 = npro.sample("Rt0", self.Rt0_dist)
 
         Rt0_trans = self.Rt_transform(Rt0)
         Rt_trans_proc = SimpleRandomWalkProcess(self.Rt_rw_dist)

--- a/model/src/pyrenew/process/rtrandomwalk.py
+++ b/model/src/pyrenew/process/rtrandomwalk.py
@@ -60,7 +60,7 @@ class RtRandomWalkProcess(RandomVariable):
         ----------
         n_timepoints : int
             Number of timepoints to sample.
-        kwargs : dict
+        **kwargs : dict, optional
             Ignored.
 
         Returns

--- a/model/src/pyrenew/process/simplerandomwalk.py
+++ b/model/src/pyrenew/process/simplerandomwalk.py
@@ -35,6 +35,7 @@ class SimpleRandomWalkProcess(RandomVariable):
         duration: int,
         name: str = "randomwalk",
         init: float = None,
+        **kwargs,
     ) -> tuple:
         """Samples from the randomwalk
 
@@ -46,6 +47,8 @@ class SimpleRandomWalkProcess(RandomVariable):
             Passed to numpyro.sample, by default "randomwalk"
         init : float, optional
             Initial point of the walk, by default None
+        kwargs : dict
+            Ignored.
 
         Returns
         -------

--- a/model/src/pyrenew/process/simplerandomwalk.py
+++ b/model/src/pyrenew/process/simplerandomwalk.py
@@ -47,7 +47,7 @@ class SimpleRandomWalkProcess(RandomVariable):
             Passed to numpyro.sample, by default "randomwalk"
         init : float, optional
             Initial point of the walk, by default None
-        kwargs : dict
+        **kwargs : dict, optional
             Ignored.
 
         Returns

--- a/model/src/test/test_latent_hospitalizations.py
+++ b/model/src/test/test_latent_hospitalizations.py
@@ -20,7 +20,7 @@ def test_hospitalizations_sample():
     np.random.seed(223)
     rt = RtRandomWalkProcess()
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_rt, *_ = rt.sample(constants={"n_timepoints": 30})
+        sim_rt, *_ = rt.sample(n_timepoints=30)
 
     gen_int = jnp.array([0.25, 0.25, 0.25, 0.25])
     i0 = 10
@@ -28,9 +28,7 @@ def test_hospitalizations_sample():
     inf1 = Infections()
 
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        inf_sampled1 = inf1.sample(
-            random_variables=dict(Rt=sim_rt, gen_int=gen_int, I0=i0),
-        )
+        inf_sampled1 = inf1.sample(Rt=sim_rt, gen_int=gen_int, I0=i0)
 
     # Testing the hospitalizations
     inf_hosp = DeterministicPMF(
@@ -67,9 +65,7 @@ def test_hospitalizations_sample():
     )
 
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_hosp_1 = hosp1.sample(
-            random_variables=dict(infections=inf_sampled1[0])
-        )
+        sim_hosp_1 = hosp1.sample(latent=inf_sampled1[0])
 
     testing.assert_array_less(
         sim_hosp_1.predicted,

--- a/model/src/test/test_latent_infections.py
+++ b/model/src/test/test_latent_infections.py
@@ -17,7 +17,7 @@ def test_infections_as_deterministic():
     np.random.seed(223)
     rt = RtRandomWalkProcess()
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_rt, *_ = rt.sample(constants={"n_timepoints": 30})
+        sim_rt, *_ = rt.sample(n_timepoints=30)
 
     gen_int = jnp.array([0.25, 0.25, 0.25, 0.25])
 
@@ -25,8 +25,8 @@ def test_infections_as_deterministic():
 
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
         obs = dict(Rt=sim_rt, I0=10, gen_int=gen_int)
-        inf_sampled1 = inf1.sample(random_variables=obs)
-        inf_sampled2 = inf1.sample(random_variables=obs)
+        inf_sampled1 = inf1.sample(**obs)
+        inf_sampled2 = inf1.sample(**obs)
 
     # Should match!
     testing.assert_array_equal(

--- a/model/src/test/test_observation_negativebinom.py
+++ b/model/src/test/test_observation_negativebinom.py
@@ -16,9 +16,8 @@ def test_negativebinom_deterministic_obs():
     np.random.seed(223)
     rates = np.random.randint(1, 5, size=10)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        dat = dict(mean=rates, counts=rates)
-        sim_pois1 = negb.sample(random_variables=dat)
-        sim_pois2 = negb.sample(random_variables=dat)
+        sim_pois1 = negb.sample(mean=rates, obs=rates)
+        sim_pois2 = negb.sample(mean=rates, obs=rates)
 
     testing.assert_array_equal(
         sim_pois1,
@@ -36,9 +35,8 @@ def test_negativebinom_random_obs():
     np.random.seed(223)
     rates = np.repeat(5, 20000)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        dat = dict(mean=rates)
-        sim_pois1 = negb.sample(random_variables=dat)
-        sim_pois2 = negb.sample(random_variables=dat)
+        sim_pois1 = negb.sample(mean=rates)
+        sim_pois2 = negb.sample(mean=rates)
 
     testing.assert_array_almost_equal(
         np.mean(sim_pois1),

--- a/model/src/test/test_observation_negativebinom.py
+++ b/model/src/test/test_observation_negativebinom.py
@@ -16,8 +16,8 @@ def test_negativebinom_deterministic_obs():
     np.random.seed(223)
     rates = np.random.randint(1, 5, size=10)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois1 = negb.sample(mean=rates, obs=rates)
-        sim_pois2 = negb.sample(mean=rates, obs=rates)
+        sim_pois1 = negb.sample(predicted=rates, obs=rates)
+        sim_pois2 = negb.sample(predicted=rates, obs=rates)
 
     testing.assert_array_equal(
         sim_pois1,
@@ -35,8 +35,8 @@ def test_negativebinom_random_obs():
     np.random.seed(223)
     rates = np.repeat(5, 20000)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois1 = negb.sample(mean=rates)
-        sim_pois2 = negb.sample(mean=rates)
+        sim_pois1 = negb.sample(predicted=rates)
+        sim_pois2 = negb.sample(predicted=rates)
 
     testing.assert_array_almost_equal(
         np.mean(sim_pois1),

--- a/model/src/test/test_observation_poisson.py
+++ b/model/src/test/test_observation_poisson.py
@@ -17,6 +17,6 @@ def test_poisson_obs():
     np.random.seed(223)
     rates = np.random.randint(1, 5, size=10)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois, *_ = pois.sample(mean=rates)
+        sim_pois, *_ = pois.sample(predicted=rates)
 
     testing.assert_array_equal(sim_pois, jnp.ceil(sim_pois))

--- a/model/src/test/test_observation_poisson.py
+++ b/model/src/test/test_observation_poisson.py
@@ -17,6 +17,6 @@ def test_poisson_obs():
     np.random.seed(223)
     rates = np.random.randint(1, 5, size=10)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois, *_ = pois.sample(random_variables=dict(rate=rates))
+        sim_pois, *_ = pois.sample(mean=rates)
 
     testing.assert_array_equal(sim_pois, jnp.ceil(sim_pois))


### PR DESCRIPTION
This PR includes the following:

- Updates the metaclasses `RandomVariable` and `Model` to use `**kwargs` for `sample()`.
- Updates all instances of these under the submodules.
- Within the `model` module, it ensures that arguments are via keywords instead of dictionaries.
- Updates the tests to reflect the change.
- Updates the demos under docs to reflect the change.

**For a new discussion**: Now that I've done this refactoring, the need to standardize the submodules became apparent. 

- When specifying the observation process for any of the models, it makes sense to have the `RandomVariable.sample()` method of `observed` class feature `mean` and `obs`. This way the `HospitalizationModel` would always expect the observation process to receive `mean` for the latent hospitalizations and `obs` for the observed hospitalizations.
- Other arguments could still be passed as now `**kwargs` are unpacked whenever calling a `RandomVariable.sample()` method.
- Like the `observed`, `process` could also have defaults for `RandomVariable.sample()`, e.g., `n_timesteps`.