### PR TITLE
add code coverage CI to pipeline code

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -20,7 +20,24 @@ jobs:
           key: ${{ runner.os }}-poetry
       - name: install poetry
         run: pip install poetry
+
       - name: install package
         run: poetry install -C pipeline
+
+      - name: install pytest-cov
+        run: poetry run -C pipeline pip install pytest-cov
+
       - name: run tests
-        run: poetry run -C pipeline pytest pipeline
+        run: poetry run -C pipeline pytest pipeline \
+            --cov=pyrenew --cov-report term --cov-report xml model
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          flags: unittests
+          file: coverage.xml
+          plugin: pycoverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -28,8 +28,7 @@ jobs:
         run: poetry run -C pipeline pip install pytest-cov
 
       - name: run tests
-        run: poetry run -C pipeline pytest pipeline \
-          --cov=pipeline --cov-report term --cov-report xml
+        run: poetry run -C pipeline pytest pipeline --cov=pipeline --cov-report term --cov-report xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -28,7 +28,7 @@ jobs:
         run: poetry run -C pipeline pip install pytest-cov
 
       - name: run tests
-        run: poetry run -C pipeline pytest pipeline \
+        run: poetry run -C pipeline pytest \
             --cov=pipeline --cov-report term --cov-report xml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: run tests
         run: poetry run -C pipeline pytest pipeline \
-            --cov=pipeline --cov-report term --cov-report xml model
+            --cov-report term --cov-report xml model
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -28,9 +28,7 @@ jobs:
         run: poetry run -C pipeline pip install pytest-cov
 
       - name: run tests
-        run: poetry run -C pipeline pytest \
-            --cov=pipeline --cov-report term --cov-report xml
-
+        run: poetry run -C pipeline pytest pipeline --cov=pipeline --cov-report term --cov-report xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -28,7 +28,8 @@ jobs:
         run: poetry run -C pipeline pip install pytest-cov
 
       - name: run tests
-        run: poetry run -C pipeline pytest pipeline --cov=pipeline --cov-report term --cov-report xml
+        run: poetry run -C pipeline pytest pipeline \
+          --cov=pipeline --cov-report term --cov-report xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: run tests
         run: poetry run -C pipeline pytest pipeline \
-            --cov-report term --cov-report xml
+            --cov "." --cov-report term --cov-report xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: run tests
         run: poetry run -C pipeline pytest pipeline \
-            --cov-report term --cov-report xml model
+            --cov-report term --cov-report xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: run tests
         run: poetry run -C pipeline pytest pipeline \
-            --cov "." --cov-report term --cov-report xml
+            --cov=pipeline --cov-report term --cov-report xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: run tests
         run: poetry run -C pipeline pytest pipeline \
-            --cov=pyrenew --cov-report term --cov-report xml model
+            --cov=pipeline --cov-report term --cov-report xml model
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
To copy the code coverage CI on the model folder of the repo.