### PR TITLE
Adding missing figures in demos.

### DIFF
--- a/model/docs/example-with-datasets.qmd
+++ b/model/docs/example-with-datasets.qmd
@@ -115,6 +115,7 @@ axs[0].plot(gen_int)
 axs[0].set_title("Generation interval")
 axs[1].plot(inf_hosp_int)
 axs[1].set_title("Infection to hospitalization interval")
+plt.show()
 ```
 
 With these two in hand, we can start building the model. First, we will define the latent hospital admissions:

--- a/model/docs/example-with-datasets.qmd
+++ b/model/docs/example-with-datasets.qmd
@@ -78,6 +78,7 @@ Let's take a look at the daily prevalence of hospital admissions.
 
 ```{python}
 #| label: fig-plot-hospital-admissions
+#| fig-cap: Daily hospital admissions from the simulated data
 import matplotlib.pyplot as plt
 
 # Rotating the x-axis labels, and only showing ~10 labels
@@ -96,6 +97,7 @@ First, we will extract two datasets we will use as deterministic quantities: the
 
 ```{python}
 #| label: fig-data-extract
+#| fig-cap: Generation interval and infection to hospitalization interval
 gen_int = datasets.load_generation_interval()
 inf_hosp_int = datasets.load_infection_admission_interval()
 

--- a/model/docs/pyrenew_demo.qmd
+++ b/model/docs/pyrenew_demo.qmd
@@ -4,19 +4,18 @@ format: gfm
 engine: jupyter
 ---
 
-This demo simulates some basic renewal process data and then fits to it using `pyrenew`.
+This demo simulates a basic renewal process data and then fits it using `pyrenew`.
 
-Assuming you've already installed Python and pip, you’ll need to first install `pyrenew`:
+You’ll need to install `pyrenew` using either poetry or pip. To install `pyrenew` using poetry, run the following command from within the directory containing the `pyrenew` project:
 
-```python
-pip install pyrenew
+```bash
+poetry install
 ```
 
-You’ll also need working
-installations of `matplotlib`, `numpy`, `jax`, `numpyro`, and `polars`:
+To install `pyrenew` using pip, run the following command:
 
-```python
-pip install matplotlib numpy jax numpyro polars
+```bash
+pip install git+https://github.com/CDCgov/multisignal-epi-inference@main#subdirectory=model
 ```
 
 To begin, run the following import section to call external modules and functions necessary to run the `pyrenew` demo. The `import` statement imports the module and the `as` statement renames the module for use within this script. The `from` statement imports a specific function from a module (named after the `.`) within a package (named before the `.`).


### PR DESCRIPTION
This is a minor fix (but important). It seems that Quarto has issues converting files to RST format. Python qmd figures should have the following:

1. Explicitly plot the figure using `plot.show()`.
2. Have the code-chunk label with no empty spaces and starting with the `fig` prefix.
3. Have a caption.

Here is an example:

```python
#| label: fig-plot-hospital-admissions
#| fig-cap: Daily hospital admissions from the simulated data
...
plt.show()
```

If either of these three is not fulfilled, Quarto+sphinx don't process the document correctly.