### PR TITLE
Renaming variables throughout for clarity

### DIFF
--- a/model/docs/example_with_datasets.qmd
+++ b/model/docs/example_with_datasets.qmd
@@ -127,7 +127,9 @@ from pyrenew import latent, deterministic, metaclass
 import jax.numpy as jnp
 import numpyro.distributions as dist
 
-inf_hosp_int = deterministic.DeterministicPMF(inf_hosp_int, name="inf_hosp_int")
+inf_hosp_int = deterministic.DeterministicPMF(
+    inf_hosp_int, name="inf_hosp_int"
+)
 
 hosp_rate = metaclass.DistributionalRV(
     dist=dist.LogNormal(jnp.log(0.05), 0.1),
@@ -135,8 +137,8 @@ hosp_rate = metaclass.DistributionalRV(
 )
 
 latent_hosp = latent.HospitalAdmissions(
-    infection_to_admission_interval=inf_hosp_int,
-    infect_hosp_rate_dist=hosp_rate,
+    infection_to_admission_interval_rv=inf_hosp_int,
+    infect_hosp_rate_rv=hosp_rate,
 )
 ```
 
@@ -173,12 +175,12 @@ Notice all the components are `RandomVariable` instances. We can now build the m
 ```{python}
 # | label: init-model
 hosp_model = model.HospitalAdmissionsModel(
-    latent_infections=latent_inf,
-    latent_admissions=latent_hosp,
-    I0=I0,
-    gen_int=gen_int,
-    Rt_process=rtproc,
-    observation_process=obs,
+    latent_infections_rv=latent_inf,
+    latent_hosp_admissions_rv=latent_hosp,
+    I0_rv=I0,
+    gen_int_rv=gen_int,
+    Rt_process_rv=rtproc,
+    hosp_admission_obs_process_rv=obs,
 )
 ```
 
@@ -208,7 +210,7 @@ axs[0].plot(sim_data.Rt)
 axs[0].set_ylabel("Rt")
 
 # Infections plot
-axs[1].plot(sim_data.sampled_admissions)
+axs[1].plot(sim_data.sampled_observed_hosp_admissions)
 axs[1].set_ylabel("Infections")
 axs[1].set_yscale("log")
 
@@ -230,7 +232,7 @@ import jax
 hosp_model.run(
     num_samples=2000,
     num_warmup=2000,
-    observed_admissions=dat["daily_hosp_admits"].to_numpy(),
+    observed_hosp_admissions=dat["daily_hosp_admits"].to_numpy(),
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
 )
@@ -244,7 +246,7 @@ We can use the `plot_posterior` method to visualize the results[^capture]:
 # | label: fig-output-hospital-admissions
 # | fig-cap: Hospital Admissions posterior distribution
 out = hosp_model.plot_posterior(
-    var="predicted_admissions",
+    var="observed_hosp_admissions",
     ylab="Hospital Admissions",
     obs_signal=dat["daily_hosp_admits"].to_numpy(),
 )
@@ -268,7 +270,7 @@ dat_w_padding = np.hstack((np.repeat(np.nan, days_to_impute), dat_w_padding))
 hosp_model.run(
     num_samples=2000,
     num_warmup=2000,
-    observed_admissions=dat_w_padding,
+    observed_hosp_admissions=dat_w_padding,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
     padding=days_to_impute,  # Padding the model
@@ -281,7 +283,7 @@ And plotting the results:
 # | label: fig-output-admissions-with-padding
 # | fig-cap: Hospital Admissions posterior distribution
 out = hosp_model.plot_posterior(
-    var="predicted_admissions",
+    var="observed_hosp_admissions",
     ylab="Hospital Admissions",
     obs_signal=dat_w_padding,
 )
@@ -343,18 +345,18 @@ Notice that the instance's `nweeks` and `len` members are passed during construc
 ```{python}
 # | label: latent-hosp-weekday
 latent_hosp_wday_effect = latent.HospitalAdmissions(
-    infection_to_admission_interval=inf_hosp_int,
-    infect_hosp_rate_dist=hosp_rate,
-    weekday_effect_dist=weekday_effect,
+    infection_to_admission_interval_rv=inf_hosp_int,
+    infect_hosp_rate_rv=hosp_rate,
+    weekday_effect_rv=weekday_effect,
 )
 
 hosp_model_weekday = model.HospitalAdmissionsModel(
-    latent_infections=latent_inf,
-    latent_admissions=latent_hosp_wday_effect,
-    I0=I0,
-    gen_int=gen_int,
-    Rt_process=rtproc,
-    observation_process=obs,
+    latent_infections_rv=latent_inf,
+    latent_hosp_admissions_rv=latent_hosp_wday_effect,
+    I0_rv=I0,
+    gen_int_rv=gen_int,
+    Rt_process_rv=rtproc,
+    hosp_admission_obs_process_rv=obs,
 )
 ```
 
@@ -365,7 +367,7 @@ Running the model (with the same padding as before):
 hosp_model_weekday.run(
     num_samples=2000,
     num_warmup=2000,
-    observed_admissions=dat_w_padding,
+    observed_hosp_admissions=dat_w_padding,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
     padding=days_to_impute,
@@ -378,7 +380,7 @@ And plotting the results:
 # | label: fig-output-admissions-padding-and-weekday
 # | fig-cap: Hospital Admissions posterior distribution
 out = hosp_model_weekday.plot_posterior(
-    var="predicted_admissions",
+    var="observed_hosp_admissions",
     ylab="Hospital Admissions",
     obs_signal=dat_w_padding,
 )

--- a/model/docs/extending_pyrenew.qmd
+++ b/model/docs/extending_pyrenew.qmd
@@ -63,11 +63,11 @@ With all the components defined, we can build the model:
 ```{python}
 # | label: build1
 model0 = RtInfectionsRenewalModel(
-    gen_int=gen_int,
-    I0=I0,
-    latent_infections=latent_infections,
-    Rt_process=rt,
-    observation_process=None,
+    gen_int_rv=gen_int,
+    I0_rv=I0,
+    latent_infections_rv=latent_infections,
+    Rt_process_rv=rt,
+    infection_obs_process_rv=None,
 )
 ```
 
@@ -239,11 +239,11 @@ latent_infections2 = InfFeedback(
 )
 
 model1 = RtInfectionsRenewalModel(
-    gen_int=gen_int,
-    I0=I0,
-    latent_infections=latent_infections2,
-    Rt_process=rt,
-    observation_process=None,
+    gen_int_rv=gen_int,
+    I0_rv=I0,
+    latent_infections_rv=latent_infections2,
+    Rt_process_rv=rt,
+    infection_obs_process_rv=None,
 )
 
 # Sampling and fitting model 0 (with no obs for infections)

--- a/model/docs/getting_started.qmd
+++ b/model/docs/getting_started.qmd
@@ -113,11 +113,11 @@ With these five pieces, we can build the basic renewal model as an instance of t
 ```{python}
 # | label: model-creation
 model1 = RtInfectionsRenewalModel(
-    gen_int=gen_int,
-    I0=I0,
-    Rt_process=rt_proc,
-    latent_infections=latent_infections,
-    observation_process=observation_process,
+    gen_int_rv=gen_int,
+    I0_rv=I0,
+    Rt_process_rv=rt_proc,
+    latent_infections_rv=latent_infections,
+    infection_obs_process_rv=observation_process,
 )
 ```
 
@@ -167,7 +167,7 @@ axs[0].plot(sim_data.Rt)
 axs[0].set_ylabel("Rt")
 
 # Infections plot
-axs[1].plot(sim_data.sampled_infections)
+axs[1].plot(sim_data.sampled_observed_infections)
 axs[1].set_ylabel("Infections")
 
 fig.suptitle("Basic renewal model")
@@ -185,7 +185,7 @@ import jax
 model1.run(
     num_warmup=2000,
     num_samples=1000,
-    observed_infections=sim_data.sampled_infections,
+    observed_infections=sim_data.sampled_observed_infections,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
 )

--- a/model/docs/pyrenew_demo.qmd
+++ b/model/docs/pyrenew_demo.qmd
@@ -112,8 +112,8 @@ inf_hosp_int = DeterministicPMF(
 )
 
 latent_admissions = HospitalAdmissions(
-    infection_to_admission_interval=inf_hosp_int,
-    infect_hosp_rate_dist=DistributionalRV(
+    infection_to_admission_interval_rv=inf_hosp_int,
+    infect_hosp_rate_rv=DistributionalRV(
         dist=dist.LogNormal(jnp.log(0.05), 0.05), name="IHR"
     ),
 )
@@ -131,12 +131,12 @@ The `HospitalAdmissionsModel` is then initialized using the initial conditions j
 ```{python}
 # Initializing the model
 hospmodel = HospitalAdmissionsModel(
-    gen_int=gen_int,
-    I0=I0,
-    latent_admissions=latent_admissions,
-    observation_process=admissions_process,
-    latent_infections=latent_infections,
-    Rt_process=Rt_process,
+    gen_int_rv=gen_int,
+    I0_rv=I0,
+    latent_hosp_admissions_rv=latent_admissions,
+    hosp_admission_obs_process_rv=admissions_process,
+    latent_infections_rv=latent_infections,
+    Rt_process_rv=Rt_process,
 )
 ```
 
@@ -151,13 +151,13 @@ x
 Visualizations of the single model output show (top) infections over the 30 time steps, (middle) hospital admissions over the 30 time steps, and (bottom)
 
 ```{python}
-#| label: fig-hosp
-#| fig-cap: Infections
+# | label: fig-hosp
+# | fig-cap: Infections
 fig, ax = plt.subplots(nrows=3, sharex=True)
 ax[0].plot(x.latent_infections)
-ax[0].set_ylim([1/5, 5])
-ax[1].plot(x.latent_admissions)
-ax[2].plot(x.sampled_admissions, 'o')
+ax[0].set_ylim([1 / 5, 5])
+ax[1].plot(x.latent_hosp_admissions)
+ax[2].plot(x.sampled_observed_hosp_admissions, "o")
 for axis in ax[:-1]:
     axis.set_yscale("log")
 ```
@@ -169,7 +169,7 @@ To fit the `hospmodel` to the simulated data, we call `hospmodel.run()`, an MCMC
 hospmodel.run(
     num_warmup=1000,
     num_samples=1000,
-    observed_admissions=x.sampled_admissions,
+    observed_hosp_admissions=x.sampled_observed_hosp_admissions,
     rng_key=jax.random.PRNGKey(54),
     mcmc_args=dict(progress_bar=False),
 )

--- a/model/docs/pyrenew_demo.qmd
+++ b/model/docs/pyrenew_demo.qmd
@@ -37,7 +37,7 @@ import numpyro.distributions as dist
 from pyrenew.process import SimpleRandomWalkProcess
 ```
 
-To understand the simple random walk process underlying the sampling within the renewal process model, we first examine a single random walk path. Using the `sample` method from an instance of the `SimpleRandomWalkProcess` class, we first create an instance of the `SimpleRandomWalkProcess` class with a normal distribution of mean = 0 and standard deviation = 0.0001 as its input. Next, the `with` statement sets the seed for the random number generator for the duration of the block that follows. Inside the `with` block, the `q_samp = q.sample(duration=100)` generates the sample instance over a duration of 100 time units. Finally, this single random walk process is visualized using `matplot.pyplot` to plot the exponential of the sample instance.
+To understand the simple random walk process underlying the sampling within the renewal process model, we first examine a single random walk path. Using the `sample` method from an instance of the `SimpleRandomWalkProcess` class, we first create an instance of the `SimpleRandomWalkProcess` class with a normal distribution of mean = 0 and standard deviation = 0.0001 as its input. Next, the `with` statement sets the seed for the random number generator for the n_timepoints of the block that follows. Inside the `with` block, the `q_samp = q.sample(n_timepoints=100)` generates the sample instance over a n_timepoints of 100 time units. Finally, this single random walk process is visualized using `matplot.pyplot` to plot the exponential of the sample instance.
 
 ```{python}
 # | label: fig-randwalk
@@ -45,7 +45,7 @@ To understand the simple random walk process underlying the sampling within the 
 np.random.seed(3312)
 q = SimpleRandomWalkProcess(dist.Normal(0, 0.001))
 with seed(rng_seed=np.random.randint(0, 1000)):
-    q_samp = q.sample(duration=100)
+    q_samp = q.sample(n_timepoints=100)
 
 plt.plot(np.exp(q_samp[0]))
 ```

--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -32,6 +32,23 @@ pytest-cov = "^5.0.0"
 pytest-mpl = "^0.17.0"
 numpydoc = "^1.7.0"
 
+[tool.numpydoc_validation]
+checks = [
+    "GL03",
+    "GL08",
+    "SS01",
+    "PR03",
+    "PR04",
+    "PR07",
+    "RT01"
+]
+ignore = [
+    "ES01",
+    "SA01",
+    "EX01",
+    "SS06",
+    "RT05"
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -49,6 +49,11 @@ ignore = [
     "SS06",
     "RT05"
 ]
+exclude = [  # don't report on objects that match any of these regex
+    '\.undocumented_method$',
+    '\.__repr__$',
+    '\.__call__$'
+]
 
 [build-system]
 requires = ["poetry-core"]

--- a/model/src/pyrenew/deterministic/nullrv.py
+++ b/model/src/pyrenew/deterministic/nullrv.py
@@ -129,7 +129,7 @@ class NullObservation(NullVariable):
 
     def sample(
         self,
-        predicted: ArrayLike,
+        mu: ArrayLike,
         obs: ArrayLike | None = None,
         name: str | None = None,
         **kwargs,
@@ -139,8 +139,8 @@ class NullObservation(NullVariable):
 
         Parameters
         ----------
-        predicted : ArrayLike
-            Rate parameter of the Poisson distribution.
+        mu : ArrayLike
+            Rate parameter of the Poisson distribution. #TODO
         obs : ArrayLike, optional
             Observed data. Defaults to None.
         name : str, optional

--- a/model/src/pyrenew/deterministic/nullrv.py
+++ b/model/src/pyrenew/deterministic/nullrv.py
@@ -140,7 +140,7 @@ class NullObservation(NullVariable):
         Parameters
         ----------
         mu : ArrayLike
-            Rate parameter of the Poisson distribution. #TODO
+            Unused parameter, represents mean of non-null distributions
         obs : ArrayLike, optional
             Observed data. Defaults to None.
         name : str, optional

--- a/model/src/pyrenew/latent/hospitaladmissions.py
+++ b/model/src/pyrenew/latent/hospitaladmissions.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple
 
 import jax.numpy as jnp
 import numpyro as npro

--- a/model/src/pyrenew/model/admissionsmodel.py
+++ b/model/src/pyrenew/model/admissionsmodel.py
@@ -87,11 +87,11 @@ class HospitalAdmissionsModel(Model):
         None
         """
         self.basic_renewal = RtInfectionsRenewalModel(
-            gen_int=gen_int_rv,
-            I0=I0_rv,
-            latent_infections=latent_infections_rv,
-            observation_process=None,  # why is this None?
-            Rt_process=Rt_process_rv,
+            gen_int_rv=gen_int_rv,
+            I0_rv=I0_rv,
+            latent_infections_rv=latent_infections_rv,
+            infection_obs_process_rv=None,  # why is this None?
+            Rt_process_rv=Rt_process_rv,
         )
 
         HospitalAdmissionsModel.validate(

--- a/model/src/pyrenew/model/admissionsmodel.py
+++ b/model/src/pyrenew/model/admissionsmodel.py
@@ -37,6 +37,12 @@ class HospModelSample(NamedTuple):
     sampled_observed_hosp_admissions: ArrayLike | None = None
 
     def __repr__(self):
+        """String representation of the HospModelSample
+
+        Returns
+        -------
+        str
+        """
         return (
             f"HospModelSample(Rt={self.Rt}, "
             f"latent_infections={self.latent_infections}, "
@@ -296,13 +302,6 @@ class HospitalAdmissionsModel(Model):
                         i0_size + padding :
                     ],
                     **kwargs,
-                )
-                # this is to accommodate the current version of test_model_hosp_no_obs_model. Not sure if we want this behavior
-                sampled_observed_hosp_admissions = au.pad_x_to_match_y(
-                    sampled_observed_hosp_admissions,
-                    latent_hosp_admissions,
-                    jnp.nan,
-                    pad_direction="start",
                 )
 
         return HospModelSample(

--- a/model/src/pyrenew/model/admissionsmodel.py
+++ b/model/src/pyrenew/model/admissionsmodel.py
@@ -37,12 +37,6 @@ class HospModelSample(NamedTuple):
     sampled_observed_hosp_admissions: ArrayLike | None = None
 
     def __repr__(self):
-        """String representation of the HospModelSample
-
-        Returns
-        -------
-        str
-        """
         return (
             f"HospModelSample(Rt={self.Rt}, "
             f"latent_infections={self.latent_infections}, "

--- a/model/src/pyrenew/model/rtinfectionsrenewalmodel.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewalmodel.py
@@ -242,7 +242,7 @@ class RtInfectionsRenewalModel(Model):
         tuple
         """
         return self.observation_process.sample(
-            predicted=predicted,
+            mu=predicted,
             obs=observed_infections,
             name=name,
             **kwargs,

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -62,7 +62,7 @@ class NegativeBinomialObservation(RandomVariable):
 
     def sample(
         self,
-        predicted: ArrayLike,
+        mu: ArrayLike,
         obs: ArrayLike | None = None,
         name: str | None = None,
         **kwargs,
@@ -72,7 +72,7 @@ class NegativeBinomialObservation(RandomVariable):
 
         Parameters
         ----------
-        predicted : ArrayLike
+        mu : ArrayLike
             Mean parameter of the negative binomial distribution.
         obs : ArrayLike, optional
             Observed data, by default None.
@@ -95,7 +95,7 @@ class NegativeBinomialObservation(RandomVariable):
             numpyro.sample(
                 name=name,
                 fn=dist.NegativeBinomial2(
-                    mean=predicted + self.eps,
+                    mean=mu + self.eps,
                     concentration=concentration,
                 ),
                 obs=obs,

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -42,7 +42,7 @@ class PoissonObservation(RandomVariable):
 
     def sample(
         self,
-        predicted: ArrayLike,
+        mu: ArrayLike,
         obs: ArrayLike | None = None,
         name: str | None = None,
         **kwargs,
@@ -52,7 +52,7 @@ class PoissonObservation(RandomVariable):
 
         Parameters
         ----------
-        predicted : ArrayLike
+        mu : ArrayLike
             Rate parameter of the Poisson distribution.
         obs : ArrayLike | None, optional
             Observed data. Defaults to None.
@@ -72,7 +72,7 @@ class PoissonObservation(RandomVariable):
         return (
             numpyro.sample(
                 name=name,
-                fn=dist.Poisson(rate=predicted + self.eps),
+                fn=dist.Poisson(rate=mu + self.eps),
                 obs=obs,
             ),
         )

--- a/model/src/pyrenew/process/rtrandomwalk.py
+++ b/model/src/pyrenew/process/rtrandomwalk.py
@@ -95,7 +95,7 @@ class RtRandomWalkProcess(RandomVariable):
 
     def sample(
         self,
-        duration: int,
+        n_timepoints: int,
         **kwargs,
     ) -> tuple:
         """
@@ -103,7 +103,7 @@ class RtRandomWalkProcess(RandomVariable):
 
         Parameters
         ----------
-        duration : int
+        n_timepoints : int
             Number of timepoints to sample.
         **kwargs : dict, optional
             Additional keyword arguments passed through to internal sample()
@@ -112,7 +112,7 @@ class RtRandomWalkProcess(RandomVariable):
         Returns
         -------
         tuple
-            With a single array of shape (duration,).
+            With a single array of shape (n_timepoints,).
         """
 
         Rt0 = npro.sample("Rt0", self.Rt0_dist)
@@ -120,7 +120,7 @@ class RtRandomWalkProcess(RandomVariable):
         Rt0_trans = self.Rt_transform(Rt0)
         Rt_trans_proc = SimpleRandomWalkProcess(self.Rt_rw_dist)
         Rt_trans_ts, *_ = Rt_trans_proc.sample(
-            duration=duration,
+            n_timepoints=n_timepoints,
             name="Rt_transformed_rw",
             init=Rt0_trans,
         )

--- a/model/src/pyrenew/process/simplerandomwalk.py
+++ b/model/src/pyrenew/process/simplerandomwalk.py
@@ -34,7 +34,7 @@ class SimpleRandomWalkProcess(RandomVariable):
 
     def sample(
         self,
-        duration: int,
+        n_timepoints: int,
         name: str = "randomwalk",
         init: float = None,
         **kwargs,
@@ -44,7 +44,7 @@ class SimpleRandomWalkProcess(RandomVariable):
 
         Parameters
         ----------
-        duration : int
+        n_timepoints : int
             Length of the walk.
         name : str, optional
             Passed to numpyro.sample, by default "randomwalk"
@@ -57,13 +57,14 @@ class SimpleRandomWalkProcess(RandomVariable):
         Returns
         -------
         tuple
-            With a single array of shape (duration,).
+            With a single array of shape (n_timepoints,).
         """
 
         if init is None:
             init = npro.sample(name + "_init", self.error_distribution)
         diffs = npro.sample(
-            name + "_diffs", self.error_distribution.expand((duration - 1,))
+            name + "_diffs",
+            self.error_distribution.expand((n_timepoints - 1,)),
         )
 
         return (init + jnp.cumsum(jnp.pad(diffs, [1, 0], constant_values=0)),)

--- a/model/src/test/test_latent_admissions.py
+++ b/model/src/test/test_latent_admissions.py
@@ -22,7 +22,7 @@ def test_admissions_sample():
     np.random.seed(223)
     rt = RtRandomWalkProcess()
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_rt, *_ = rt.sample(duration=30)
+        sim_rt, *_ = rt.sample(n_timepoints=30)
 
     gen_int = jnp.array([0.5, 0.1, 0.1, 0.2, 0.1])
     i0 = 10 * jnp.ones_like(gen_int)

--- a/model/src/test/test_latent_admissions.py
+++ b/model/src/test/test_latent_admissions.py
@@ -60,16 +60,16 @@ def test_admissions_sample():
     )
 
     hosp1 = HospitalAdmissions(
-        infection_to_admission_interval=inf_hosp,
-        infect_hosp_rate_dist=DistributionalRV(
+        infection_to_admission_interval_rv=inf_hosp,
+        infect_hosp_rate_rv=DistributionalRV(
             dist=dist.LogNormal(jnp.log(0.05), 0.05), name="IHR"
         ),
     )
 
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_hosp_1 = hosp1.sample(latent=inf_sampled1[0])
+        sim_hosp_1 = hosp1.sample(latent_infections=inf_sampled1[0])
 
     testing.assert_array_less(
-        sim_hosp_1.predicted,
+        sim_hosp_1.observed_hosp_admissions,
         inf_sampled1[0],
     )

--- a/model/src/test/test_latent_infections.py
+++ b/model/src/test/test_latent_infections.py
@@ -19,7 +19,7 @@ def test_infections_as_deterministic():
     np.random.seed(223)
     rt = RtRandomWalkProcess()
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_rt, *_ = rt.sample(duration=30)
+        sim_rt, *_ = rt.sample(n_timepoints=30)
 
     gen_int = jnp.array([0.25, 0.25, 0.25, 0.25])
 

--- a/model/src/test/test_model_basic_renewal.py
+++ b/model/src/test/test_model_basic_renewal.py
@@ -39,11 +39,11 @@ def test_model_basicrenewal_no_timepoints_or_observations():
     rt = RtRandomWalkProcess()
 
     model1 = RtInfectionsRenewalModel(
-        I0=I0,
-        gen_int=gen_int,
-        latent_infections=latent_infections,
-        observation_process=observed_infections,
-        Rt_process=rt,
+        I0_rv=I0,
+        gen_int_rv=gen_int,
+        latent_infections_rv=latent_infections,
+        infection_obs_process_rv=observed_infections,
+        Rt_process_rv=rt,
     )
 
     np.random.seed(2203)
@@ -72,11 +72,11 @@ def test_model_basicrenewal_both_timepoints_and_observations():
     rt = RtRandomWalkProcess()
 
     model1 = RtInfectionsRenewalModel(
-        I0=I0,
-        gen_int=gen_int,
-        latent_infections=latent_infections,
-        observation_process=observed_infections,
-        Rt_process=rt,
+        I0_rv=I0,
+        gen_int_rv=gen_int,
+        latent_infections_rv=latent_infections,
+        infection_obs_process_rv=observed_infections,
+        Rt_process_rv=rt,
     )
 
     np.random.seed(2203)
@@ -112,12 +112,12 @@ def test_model_basicrenewal_no_obs_model():
     rt = RtRandomWalkProcess()
 
     model0 = RtInfectionsRenewalModel(
-        gen_int=gen_int,
-        I0=I0,
-        latent_infections=latent_infections,
-        Rt_process=rt,
+        gen_int_rv=gen_int,
+        I0_rv=I0,
+        latent_infections_rv=latent_infections,
+        Rt_process_rv=rt,
         # Explicitly use None, this should call the NullObservation
-        observation_process=None,
+        infection_obs_process_rv=None,
     )
 
     # Sampling and fitting model 0 (with no obs for infections)
@@ -126,10 +126,10 @@ def test_model_basicrenewal_no_obs_model():
         model0_samp = model0.sample(n_timepoints_to_simulate=30)
     model0_samp.Rt
     model0_samp.latent_infections
-    model0_samp.sampled_infections
+    model0_samp.sampled_observed_infections
 
     # Generating
-    model0.observation_process = NullObservation()
+    model0.infection_obs_process_rv = NullObservation()
     np.random.seed(223)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
         model1_samp = model0.sample(n_timepoints_to_simulate=30)
@@ -139,7 +139,8 @@ def test_model_basicrenewal_no_obs_model():
         model0_samp.latent_infections, model1_samp.latent_infections
     )
     np.testing.assert_array_equal(
-        model0_samp.sampled_infections, model1_samp.sampled_infections
+        model0_samp.sampled_observed_infections,
+        model1_samp.sampled_observed_infections,
     )
 
     model0.run(
@@ -184,11 +185,11 @@ def test_model_basicrenewal_with_obs_model():
     rt = RtRandomWalkProcess()
 
     model1 = RtInfectionsRenewalModel(
-        I0=I0,
-        gen_int=gen_int,
-        latent_infections=latent_infections,
-        observation_process=observed_infections,
-        Rt_process=rt,
+        I0_rv=I0,
+        gen_int_rv=gen_int,
+        latent_infections_rv=latent_infections,
+        infection_obs_process_rv=observed_infections,
+        Rt_process_rv=rt,
     )
 
     # Sampling and fitting model 1 (with obs infections)
@@ -200,7 +201,7 @@ def test_model_basicrenewal_with_obs_model():
         num_warmup=500,
         num_samples=500,
         rng_key=jax.random.PRNGKey(22),
-        observed_infections=model1_samp.sampled_infections,
+        observed_infections=model1_samp.sampled_observed_infections,
     )
 
     inf = model1.spread_draws(["latent_infections"])
@@ -253,11 +254,11 @@ def test_model_basicrenewal_plot() -> plt.Figure:
     rt = RtRandomWalkProcess()
 
     model1 = RtInfectionsRenewalModel(
-        I0=I0,
-        gen_int=gen_int,
-        latent_infections=latent_infections,
-        observation_process=observed_infections,
-        Rt_process=rt,
+        I0_rv=I0,
+        gen_int_rv=gen_int,
+        latent_infections_rv=latent_infections,
+        infection_obs_process_rv=observed_infections,
+        Rt_process_rv=rt,
     )
 
     # Sampling and fitting model 1 (with obs infections)
@@ -269,12 +270,12 @@ def test_model_basicrenewal_plot() -> plt.Figure:
         num_warmup=500,
         num_samples=500,
         rng_key=jax.random.PRNGKey(22),
-        observed_infections=model1_samp.sampled_infections,
+        observed_infections=model1_samp.sampled_observed_infections,
     )
 
     return model1.plot_posterior(
         var="latent_infections",
-        obs_signal=model1_samp.sampled_infections,
+        obs_signal=model1_samp.sampled_observed_infections,
     )
 
 
@@ -296,11 +297,11 @@ def test_model_basicrenewal_padding() -> None:  # numpydoc ignore=GL08
     rt = RtRandomWalkProcess()
 
     model1 = RtInfectionsRenewalModel(
-        I0=I0,
-        gen_int=gen_int,
-        latent_infections=latent_infections,
-        observation_process=observed_infections,
-        Rt_process=rt,
+        I0_rv=I0,
+        gen_int_rv=gen_int,
+        latent_infections_rv=latent_infections,
+        infection_obs_process_rv=observed_infections,
+        Rt_process_rv=rt,
     )
 
     # Sampling and fitting model 1 (with obs infections)
@@ -309,7 +310,7 @@ def test_model_basicrenewal_padding() -> None:  # numpydoc ignore=GL08
         model1_samp = model1.sample(n_timepoints_to_simulate=30)
 
     new_obs = jnp.hstack(
-        [jnp.repeat(jnp.nan, 5), model1_samp.sampled_infections[5:]],
+        [jnp.repeat(jnp.nan, 5), model1_samp.sampled_observed_infections[5:]],
     )
 
     model1.run(

--- a/model/src/test/test_observation_negativebinom.py
+++ b/model/src/test/test_observation_negativebinom.py
@@ -17,8 +17,8 @@ def test_negativebinom_deterministic_obs():
     np.random.seed(223)
     rates = np.random.randint(1, 5, size=10)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois1 = negb.sample(predicted=rates, obs=rates)
-        sim_pois2 = negb.sample(predicted=rates, obs=rates)
+        sim_pois1 = negb.sample(mu=rates, obs=rates)
+        sim_pois2 = negb.sample(mu=rates, obs=rates)
 
     testing.assert_array_equal(
         sim_pois1,
@@ -36,8 +36,8 @@ def test_negativebinom_random_obs():
     np.random.seed(223)
     rates = np.repeat(5, 20000)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois1 = negb.sample(predicted=rates)
-        sim_pois2 = negb.sample(predicted=rates)
+        sim_pois1 = negb.sample(mu=rates)
+        sim_pois2 = negb.sample(mu=rates)
 
     testing.assert_array_almost_equal(
         np.mean(sim_pois1),

--- a/model/src/test/test_observation_poisson.py
+++ b/model/src/test/test_observation_poisson.py
@@ -18,6 +18,6 @@ def test_poisson_obs():
     np.random.seed(223)
     rates = np.random.randint(1, 5, size=10)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        sim_pois, *_ = pois.sample(predicted=rates)
+        sim_pois, *_ = pois.sample(mu=rates)
 
     testing.assert_array_equal(sim_pois, jnp.ceil(sim_pois))


### PR DESCRIPTION
Closes https://github.com/CDCgov/multisignal-epi-inference/issues/156.

No changes to any of the model workings. Just renaming variables to make things easier to follow.

For example:

- objects named `x_dist` that are actually random variables are renamed `x_rv`
- object with vague names like `latent` are renamed to be more specific like `latent_infections` or `latent_hosp_admissions`
- `predicted` as a descriptor is replaced by `observed` or `sampled` where appropriate
- acronyms like `ihr` are replaced by more descriptive terms like `infection_hosp_rate`
- `i0` is consistently formatted as `I0`