### PR TITLE
Revert "restrict filelock version"

### DIFF
--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -18,7 +18,6 @@ polars = "^0.20.13"
 pillow = "^10.3.0" # See #56 on CDCgov/multisignal-epi-inference
 nbconvert = "^7.16.4"
 pytest-mpl = "^0.17.0"
-filelock = "<=3.14"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
This was fixed automatically thanks to the latest version of filelock being yanked.

Reverts CDCgov/multisignal-epi-inference#182