### PR TITLE
Adding Repository Structure And Resources Sections To The README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,111 +22,16 @@ This repository was created for use by CDC programs to collaborate on public hea
 
 The structure of the MSR, ignoring the `docs` folder, `__init__.py`s, and image files, can be found via: `tree -I "docs|__init__.py|*.png|*.csv"`. Note, this structure will quite certainly change over 2024 and beyond, yet having this snapshot should still be useful for establishing an impression of the codebase.
 
-```
-.
-├── README.md
-├── _typos.toml
-├── model
-│   ├── Dockerfile
-│   ├── LICENSE
-│   ├── Makefile
-│   ├── README.md
-│   ├── equations.md
-│   ├── pyproject.toml
-│   └── src
-│       ├── pyrenew
-│       │   ├── arrayutils.py
-│       │   ├── convolve.py
-│       │   ├── datasets
-│       │   │   ├── data-raw
-│       │   │   │   ├── README.md
-│       │   │   │   ├── generation_interval.py
-│       │   │   │   ├── infection_admission_interval.py
-│       │   │   │   └── wastewater.R
-│       │   │   ├── generation_interval.py
-│       │   │   ├── generation_interval.tsv
-│       │   │   ├── infection_admission_interval.py
-│       │   │   ├── infection_admission_interval.tsv
-│       │   │   ├── wastewater.py
-│       │   │   └── wastewater.tsv
-│       │   ├── deterministic
-│       │   │   ├── deterministic.py
-│       │   │   ├── deterministicpmf.py
-│       │   │   ├── nullrv.py
-│       │   │   └── process.py
-│       │   ├── distutil.py
-│       │   ├── latent
-│       │   │   ├── hospitaladmissions.py
-│       │   │   ├── infection_functions.py
-│       │   │   ├── infection_seeding_method.py
-│       │   │   ├── infection_seeding_process.py
-│       │   │   ├── infections.py
-│       │   │   └── infectionswithfeedback.py
-│       │   ├── math.py
-│       │   ├── mcmcutils.py
-│       │   ├── metaclass.py
-│       │   ├── model
-│       │   │   ├── admissionsmodel.py
-│       │   │   └── rtinfectionsrenewalmodel.py
-│       │   ├── observation
-│       │   │   ├── negativebinomial.py
-│       │   │   └── poisson.py
-│       │   ├── process
-│       │   │   ├── ar.py
-│       │   │   ├── firstdifferencear.py
-│       │   │   ├── rtperiodicdiff.py
-│       │   │   ├── rtrandomwalk.py
-│       │   │   └── simplerandomwalk.py
-│       │   ├── regression.py
-│       │   └── transformation
-│       │       └── builtin.py
-│       └── test
-│           ├── baseline
-│           ├── test_ar_process.py
-│           ├── test_arrayutils.py
-│           ├── test_convolve_scanners.py
-│           ├── test_datasets.py
-│           ├── test_deterministic.py
-│           ├── test_first_difference_ar.py
-│           ├── test_infection_functions.py
-│           ├── test_infection_seeding_method.py
-│           ├── test_infection_seeding_process.py
-│           ├── test_infectionsrtfeedback.py
-│           ├── test_latent_admissions.py
-│           ├── test_latent_infections.py
-│           ├── test_leslie_matrix.py
-│           ├── test_logistic_susceptibility_adjustment.py
-│           ├── test_model_basic_renewal.py
-│           ├── test_model_hospitalizations.py
-│           ├── test_observation_negativebinom.py
-│           ├── test_observation_poisson.py
-│           ├── test_process_asymptotics.py
-│           ├── test_random_walk.py
-│           ├── test_regression.py
-│           ├── test_rtperiodicdiff.py
-│           └── test_transformation.py
-├── pipeline
-│   ├── LICENSE
-│   ├── README.md
-│   ├── pipeline
-│   │   └── placeholder.py
-│   ├── pyproject.toml
-│   └── tests
-│       └── test_placeholder.py
-├── pyproject.toml
-└── src
-    └── test
-        └── baseline
-
-19 directories, 74 files
-```
+<!--
+Add link to developer documentation in the above paragraph
+-->
 
 ## MSR Relevant Resources
 
-* Again, [The MSR Website](https://cdcgov.github.io/multisignal-epi-inference/tutorials/index.html)
-* [The Model Equations Sheet](https://github.com/CDCgov/multisignal-epi-inference/blob/main/model/equations.md)
-* The paper _[Semi-mechanistic Bayesian modelling of COVID-19 with renewal processes](https://academic.oup.com/jrsssa/article-pdf/186/4/601/54770289/qnad030.pdf)_ (2023)
-* The paper _[Unifying incidence and prevalence under a time-varying general branching process](https://link.springer.com/content/pdf/10.1007/s00285-023-01958-w.pdf)_
+* [The MSR Website](https://cdcgov.github.io/multisignal-epi-inference/tutorials/index.html)...for tutorials on using MSR, general documentation, and additional context.
+* [The Model Equations Sheet](https://github.com/CDCgov/multisignal-epi-inference/blob/main/model/equations.md)...for the mathematical representation of the renewal processes and models MSR supports.
+* The paper _[Semi-mechanistic Bayesian modelling of COVID-19 with renewal processes](https://academic.oup.com/jrsssa/article-pdf/186/4/601/54770289/qnad030.pdf)_ (2023)...for further context on renewal processes in epidemiology.
+* The paper _[Unifying incidence and prevalence under a time-varying general branching process](https://link.springer.com/content/pdf/10.1007/s00285-023-01958-w.pdf)_ (2023)for further context on renewal processes in epidemiology.
 
 ## Public Domain Standard Notice
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,116 @@ Examples using the library can be found on the project's website [here](https://
 
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.
 
+## Repository Structure
+
+The structure of the MSR, ignoring the `docs` folder, `__init__.py`s, and image files, can be found via: `tree -I "docs|__init__.py|*.png|*.csv"`. Note, this structure will quite certainly change over 2024 and beyond, yet having this snapshot should still be useful for establishing an impression of the codebase.
+
+```
+.
+├── README.md
+├── _typos.toml
+├── model
+│   ├── Dockerfile
+│   ├── LICENSE
+│   ├── Makefile
+│   ├── README.md
+│   ├── equations.md
+│   ├── pyproject.toml
+│   └── src
+│       ├── pyrenew
+│       │   ├── arrayutils.py
+│       │   ├── convolve.py
+│       │   ├── datasets
+│       │   │   ├── data-raw
+│       │   │   │   ├── README.md
+│       │   │   │   ├── generation_interval.py
+│       │   │   │   ├── infection_admission_interval.py
+│       │   │   │   └── wastewater.R
+│       │   │   ├── generation_interval.py
+│       │   │   ├── generation_interval.tsv
+│       │   │   ├── infection_admission_interval.py
+│       │   │   ├── infection_admission_interval.tsv
+│       │   │   ├── wastewater.py
+│       │   │   └── wastewater.tsv
+│       │   ├── deterministic
+│       │   │   ├── deterministic.py
+│       │   │   ├── deterministicpmf.py
+│       │   │   ├── nullrv.py
+│       │   │   └── process.py
+│       │   ├── distutil.py
+│       │   ├── latent
+│       │   │   ├── hospitaladmissions.py
+│       │   │   ├── infection_functions.py
+│       │   │   ├── infection_seeding_method.py
+│       │   │   ├── infection_seeding_process.py
+│       │   │   ├── infections.py
+│       │   │   └── infectionswithfeedback.py
+│       │   ├── math.py
+│       │   ├── mcmcutils.py
+│       │   ├── metaclass.py
+│       │   ├── model
+│       │   │   ├── admissionsmodel.py
+│       │   │   └── rtinfectionsrenewalmodel.py
+│       │   ├── observation
+│       │   │   ├── negativebinomial.py
+│       │   │   └── poisson.py
+│       │   ├── process
+│       │   │   ├── ar.py
+│       │   │   ├── firstdifferencear.py
+│       │   │   ├── rtperiodicdiff.py
+│       │   │   ├── rtrandomwalk.py
+│       │   │   └── simplerandomwalk.py
+│       │   ├── regression.py
+│       │   └── transformation
+│       │       └── builtin.py
+│       └── test
+│           ├── baseline
+│           ├── test_ar_process.py
+│           ├── test_arrayutils.py
+│           ├── test_convolve_scanners.py
+│           ├── test_datasets.py
+│           ├── test_deterministic.py
+│           ├── test_first_difference_ar.py
+│           ├── test_infection_functions.py
+│           ├── test_infection_seeding_method.py
+│           ├── test_infection_seeding_process.py
+│           ├── test_infectionsrtfeedback.py
+│           ├── test_latent_admissions.py
+│           ├── test_latent_infections.py
+│           ├── test_leslie_matrix.py
+│           ├── test_logistic_susceptibility_adjustment.py
+│           ├── test_model_basic_renewal.py
+│           ├── test_model_hospitalizations.py
+│           ├── test_observation_negativebinom.py
+│           ├── test_observation_poisson.py
+│           ├── test_process_asymptotics.py
+│           ├── test_random_walk.py
+│           ├── test_regression.py
+│           ├── test_rtperiodicdiff.py
+│           └── test_transformation.py
+├── pipeline
+│   ├── LICENSE
+│   ├── README.md
+│   ├── pipeline
+│   │   └── placeholder.py
+│   ├── pyproject.toml
+│   └── tests
+│       └── test_placeholder.py
+├── pyproject.toml
+└── src
+    └── test
+        └── baseline
+
+19 directories, 74 files
+```
+
+## MSR Relevant Resources
+
+* Again, [The MSR Website](https://cdcgov.github.io/multisignal-epi-inference/tutorials/index.html)
+* [The Model Equations Sheet](https://github.com/CDCgov/multisignal-epi-inference/blob/main/model/equations.md)
+* The paper _[Semi-mechanistic Bayesian modelling of COVID-19 with renewal processes](https://academic.oup.com/jrsssa/article-pdf/186/4/601/54770289/qnad030.pdf)_ (2023)
+* The paper _[Unifying incidence and prevalence under a time-varying general branching process](https://link.springer.com/content/pdf/10.1007/s00285-023-01958-w.pdf)_
+
 ## Public Domain Standard Notice
 
 This repository constitutes a work of the United States Government and is not

--- a/README.md
+++ b/README.md
@@ -12,26 +12,17 @@
 
 The **Multisignal Renewal Project** aims to develop a modeling framework that leverages multiple data sources to enhance CDC's epidemiological modeling capabilities. The project's goal is twofold: (a) **create a Python library** that provides a flexible renewal modeling framework and (b) **develop a pipeline** that leverages this framework to estimate epidemiological parameters from multiple data sources and produce forecasts. The library and pipeline are located in the [**model/**](https://github.com/CDCgov/multisignal-epi-inference/tree/main/model) and [**pipeline/**](https://github.com/CDCgov/multisignal-epi-inference/tree/main/pipeline/) directories of the GitHub repository, respectively.
 
-Examples using the library can be found on the project's website [here](https://cdcgov.github.io/multisignal-epi-inference/tutorials/index.html).
+## Resources
+
+* [The MSR Website](https://cdcgov.github.io/multisignal-epi-inference/tutorials/index.html) provides general documentation and tutorials on using MSR.
+* [The Model Equations Sheet](https://github.com/CDCgov/multisignal-epi-inference/blob/main/model/equations.md) describe the mathematics of the renewal processes and models MSR supports.
+* Additional reading on renewal processes in epidemiology
+  * [_Semi-mechanistic Bayesian modelling of COVID-19 with renewal processes_](https://academic.oup.com/jrsssa/article-pdf/186/4/601/54770289/qnad030.pdf)
+  * [_Unifying incidence and prevalence under a time-varying general branching process_](https://link.springer.com/content/pdf/10.1007/s00285-023-01958-w.pdf)
 
 ## General Disclaimer
 
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.
-
-## Repository Structure
-
-The structure of the MSR, ignoring the `docs` folder, `__init__.py`s, and image files, can be found via: `tree -I "docs|__init__.py|*.png|*.csv"`. Note, this structure will quite certainly change over 2024 and beyond, yet having this snapshot should still be useful for establishing an impression of the codebase.
-
-<!--
-Add link to developer documentation in the above paragraph
--->
-
-## MSR Relevant Resources
-
-* [The MSR Website](https://cdcgov.github.io/multisignal-epi-inference/tutorials/index.html)...for tutorials on using MSR, general documentation, and additional context.
-* [The Model Equations Sheet](https://github.com/CDCgov/multisignal-epi-inference/blob/main/model/equations.md)...for the mathematical representation of the renewal processes and models MSR supports.
-* The paper _[Semi-mechanistic Bayesian modelling of COVID-19 with renewal processes](https://academic.oup.com/jrsssa/article-pdf/186/4/601/54770289/qnad030.pdf)_ (2023)...for further context on renewal processes in epidemiology.
-* The paper _[Unifying incidence and prevalence under a time-varying general branching process](https://link.springer.com/content/pdf/10.1007/s00285-023-01958-w.pdf)_ (2023)for further context on renewal processes in epidemiology.
 
 ## Public Domain Standard Notice
 


### PR DESCRIPTION
This is a small pull request that adds two simple items to the README file: the structure of the MSR repository via `tree` and a Resources section. 

A Repository Structure section enables users to get an impression of the MSR repository very quickly. While MSR's structure will change, requiring the Repository Structure section of the README to be manually revised, revisions need not be done frequently, since the design of MSR currently is such that further updates are unlikely to deviate significantly enough for the existing but outdated `tree` output to cease to be useful. The only request I have here for reviewers is to provide some thoughts for what to ignore when running `tree`.

Resources are helpful for newcomers and for those who've forgotten where to find particular items relevant to the project. I have added four resources. More resources can be added by others, including the reviewers. 

As for the placement of the sections in the README, I thought that after the General Disclaimer worked well, since Public Domain Standard Notice becomes less MSR and or CDC specific. 