### PR TITLE
Add diagnostics using arviz to tutorials

### DIFF
--- a/model/docs/example_with_datasets.qmd
+++ b/model/docs/example_with_datasets.qmd
@@ -238,7 +238,7 @@ hosp_model.run(
     num_warmup=2000,
     data_observed_hosp_admissions=dat["daily_hosp_admits"].to_numpy(),
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False,num_chains=2),
+    mcmc_args=dict(progress_bar=False, num_chains=2),
 )
 ```
 
@@ -283,7 +283,7 @@ hosp_model.run(
     num_warmup=2000,
     data_observed_hosp_admissions=dat_w_padding,
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False,num_chains=2),
+    mcmc_args=dict(progress_bar=False, num_chains=2),
     padding=days_to_impute,  # Padding the model
 )
 ```

--- a/model/docs/example_with_datasets.qmd
+++ b/model/docs/example_with_datasets.qmd
@@ -302,13 +302,13 @@ out = hosp_model.plot_posterior(
 )
 ```
 
-We can use [ArviZ](https://www.arviz.org/) to visualize the results. Convert the fitted model to Arviz InferenceData object:
+We can use [ArviZ](https://www.arviz.org/) to visualize the results. Let's start by converting the fitted model to Arviz InferenceData object:
 ```{python}
 # | label: convert-inferenceData
 import arviz as az
 idata = az.from_numpyro(hosp_model.mcmc)
 ```
-Compute model diagnostics:
+We obtain the summary of model diagnostics and print the diagnostics for `latent_hospital_admissions[1]`
 ```{python}
 # | label: diagnostics
 # | warning: false

--- a/model/docs/example_with_datasets.qmd
+++ b/model/docs/example_with_datasets.qmd
@@ -238,7 +238,7 @@ hosp_model.run(
     num_warmup=2000,
     data_observed_hosp_admissions=dat["daily_hosp_admits"].to_numpy(),
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False),
+    mcmc_args=dict(progress_bar=False,num_chains=2),
 )
 ```
 
@@ -283,7 +283,7 @@ hosp_model.run(
     num_warmup=2000,
     data_observed_hosp_admissions=dat_w_padding,
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False),
+    mcmc_args=dict(progress_bar=False,num_chains=2),
     padding=days_to_impute,  # Padding the model
 )
 ```
@@ -308,6 +308,18 @@ We can use [ArviZ](https://www.arviz.org/) to visualize the results. Convert the
 import arviz as az
 idata = az.from_numpyro(hosp_model.mcmc)
 ```
+Compute model diagnostics:
+```{python}
+# | label: diagnostics
+# | warning: false
+diagnostic_stats_summary = az.summary(
+    idata.posterior,
+    kind='diagnostics',
+    )
+
+print(diagnostic_stats_summary.loc['latent_hospital_admissions[1]'])
+```
+
 Below we plot 90% and 50% highest density intervals for latent hospital admissions using [plot_hdi](https://python.arviz.org/en/stable/api/generated/arviz.plot_hdi.html):
 
 ```{python}

--- a/model/docs/getting_started.qmd
+++ b/model/docs/getting_started.qmd
@@ -192,7 +192,7 @@ model1.run(
     num_samples=1000,
     data_observed_infections=sim_data.observed_infections,
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False),
+    mcmc_args=dict(progress_bar=False,num_chains=2),
 )
 ```
 
@@ -210,6 +210,18 @@ We can use [ArviZ](https://www.arviz.org/) package to create model diagnostics a
 #| label: convert-inference-data
 import arviz as az
 idata = az.from_numpyro(model1.mcmc)
+```
+
+and use the InferenceData to compute the model-fit diagnostics. Here, we show diagnostic summary for the first 10 effective reproduction number $R_t$.
+
+```{python}
+#| label: diagnostics
+diagnostic_stats_summary = az.summary(
+    idata.posterior['Rt'],
+    kind='diagnostics',
+    )
+
+print(diagnostic_stats_summary[:10])
 ```
 
 Below we use `plot_trace` to inspect the trace of the first 10 $R_t$ estimates.

--- a/model/docs/getting_started.qmd
+++ b/model/docs/getting_started.qmd
@@ -192,7 +192,7 @@ model1.run(
     num_samples=1000,
     data_observed_infections=sim_data.observed_infections,
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False,num_chains=2),
+    mcmc_args=dict(progress_bar=False, num_chains=2),
 )
 ```
 


### PR DESCRIPTION
Two changes made:
 - added mcmc diagnostics to the two tutorials
 - changed `num_chains=2` from deafult value of 1. This was required to suppress a warning about convergence diagnostics