### PR TITLE
Changing `Model.sample` To `Model.model`

### DIFF
--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [{path = "datasets/*.rds"}]
 
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 numpyro = "^0.15.0"
 jax = "^0.4.25"
 numpy = "^1.26.4"

--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [{path = "datasets/*.rds"}]
 
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.12"
 numpyro = "^0.15.0"
 jax = "^0.4.25"
 numpy = "^1.26.4"

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -365,6 +365,7 @@ class Model(metaclass=ABCMeta):
         if mcmc_args is None:
             mcmc_args = dict()
 
+        # placeholder for changing this
         self.kernel = NUTS(
             model=self.sample,
             **nuts_args,

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -320,7 +320,7 @@ class Model(metaclass=ABCMeta):
         **kwargs,
     ) -> tuple:
         """
-        Sample method of the model
+        Sample method of the model.
 
         The method design in the class should have at least kwargs.
 
@@ -335,6 +335,22 @@ class Model(metaclass=ABCMeta):
         tuple
         """
         pass
+
+    def model(self, **kwargs) -> tuple:
+        """
+        Alias for the sample method.
+
+        Parameters
+        ----------
+        **kwargs : dict, optional
+            Additional keyword arguments passed through to internal `sample()`
+            calls, should there be any.
+
+        Returns
+        -------
+        tuple
+        """
+        return self.sample(**kwargs)
 
     def _init_model(
         self,
@@ -367,7 +383,7 @@ class Model(metaclass=ABCMeta):
 
         # placeholder for changing this
         self.kernel = NUTS(
-            model=self.sample,
+            model=self.model,
             **nuts_args,
         )
 

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -381,7 +381,6 @@ class Model(metaclass=ABCMeta):
         if mcmc_args is None:
             mcmc_args = dict()
 
-        # placeholder for changing this
         self.kernel = NUTS(
             model=self.model,
             **nuts_args,

--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -532,7 +532,7 @@ class Model(metaclass=ABCMeta):
             rng_key = jr.key(rand_int)
 
         predictive = Predictive(
-            model=self.sample,
+            model=self.model,
             posterior_samples=self.mcmc.get_samples(),
             **numpyro_predictive_args,
         )
@@ -569,7 +569,7 @@ class Model(metaclass=ABCMeta):
             rng_key = jr.key(rand_int)
 
         predictive = Predictive(
-            model=self.sample,
+            model=self.model,
             posterior_samples=None,
             **numpyro_predictive_args,
         )


### PR DESCRIPTION
This PR exists to change the following, within `metaclass.py`

```python
self.kernel = NUTS(
    model=self.sample,
    **nuts_args,
)
```

to the following:

```python
self.kernel = NUTS(
    model=self.model,
    **nuts_args,
)
```

This change is due given consensus that `model` is clearer than `sample` in the context above.
