### PR TITLE
Rename `SeedInfectionsExponential` For Clarity

### DIFF
--- a/model/docs/example_with_datasets.qmd
+++ b/model/docs/example_with_datasets.qmd
@@ -147,7 +147,7 @@ The `inf_hosp_int` is a `DeterministicPMF` object that takes the infection to ho
 ```{python}
 # | label: initializing-rest-of-model
 from pyrenew import model, process, observation, metaclass, transformation
-from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsViaExpGrowth
+from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsExponentialGrowth
 
 # Infection process
 latent_inf = latent.Infections()
@@ -156,7 +156,7 @@ I0 = InfectionSeedingProcess(
     metaclass.DistributionalRV(
         dist=dist.LogNormal(loc=jnp.log(100), scale=0.5), name="I0"
     ),
-    SeedInfectionsViaExpGrowth(
+    SeedInfectionsExponentialGrowth(
         gen_int_array.size,
         deterministic.DeterministicVariable(0.5, name="rate"),
     ),

--- a/model/docs/example_with_datasets.qmd
+++ b/model/docs/example_with_datasets.qmd
@@ -147,7 +147,7 @@ The `inf_hosp_int` is a `DeterministicPMF` object that takes the infection to ho
 ```{python}
 # | label: initializing-rest-of-model
 from pyrenew import model, process, observation, metaclass, transformation
-from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsExponential
+from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsViaExpGrowth
 
 # Infection process
 latent_inf = latent.Infections()
@@ -156,7 +156,7 @@ I0 = InfectionSeedingProcess(
     metaclass.DistributionalRV(
         dist=dist.LogNormal(loc=jnp.log(100), scale=0.5), name="I0"
     ),
-    SeedInfectionsExponential(
+    SeedInfectionsViaExpGrowth(
         gen_int_array.size,
         deterministic.DeterministicVariable(0.5, name="rate"),
     ),

--- a/model/docs/extending_pyrenew.qmd
+++ b/model/docs/extending_pyrenew.qmd
@@ -30,7 +30,7 @@ from pyrenew.latent import InfectionsWithFeedback
 from pyrenew.model import RtInfectionsRenewalModel
 from pyrenew.process import RtRandomWalkProcess
 from pyrenew.metaclass import DistributionalRV
-from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsViaExpGrowth
+from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsExponentialGrowth
 import pyrenew.transformation as t
 ```
 
@@ -45,7 +45,7 @@ feedback_strength = DeterministicVariable(0.05, name="feedback_strength")
 I0 = InfectionSeedingProcess(
     "I0_seeding",
     DistributionalRV(dist=dist.LogNormal(0, 1), name="I0"),
-    SeedInfectionsViaExpGrowth(
+    SeedInfectionsExponentialGrowth(
         gen_int_array.size,
         DeterministicVariable(0.5, name="rate"),
     ),

--- a/model/docs/extending_pyrenew.qmd
+++ b/model/docs/extending_pyrenew.qmd
@@ -30,7 +30,7 @@ from pyrenew.latent import InfectionsWithFeedback
 from pyrenew.model import RtInfectionsRenewalModel
 from pyrenew.process import RtRandomWalkProcess
 from pyrenew.metaclass import DistributionalRV
-from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsExponential
+from pyrenew.latent import InfectionSeedingProcess, SeedInfectionsViaExpGrowth
 import pyrenew.transformation as t
 ```
 
@@ -45,7 +45,7 @@ feedback_strength = DeterministicVariable(0.05, name="feedback_strength")
 I0 = InfectionSeedingProcess(
     "I0_seeding",
     DistributionalRV(dist=dist.LogNormal(0, 1), name="I0"),
-    SeedInfectionsExponential(
+    SeedInfectionsViaExpGrowth(
         gen_int_array.size,
         DeterministicVariable(0.5, name="rate"),
     ),

--- a/model/src/pyrenew/latent/__init__.py
+++ b/model/src/pyrenew/latent/__init__.py
@@ -10,8 +10,8 @@ from pyrenew.latent.infection_functions import (
 )
 from pyrenew.latent.infection_seeding_method import (
     InfectionSeedMethod,
-    SeedInfectionsExponential,
     SeedInfectionsFromVec,
+    SeedInfectionsViaExpGrowth,
     SeedInfectionsZeroPad,
 )
 from pyrenew.latent.infection_seeding_process import InfectionSeedingProcess
@@ -25,7 +25,7 @@ __all__ = [
     "compute_infections_from_rt",
     "compute_infections_from_rt_with_feedback",
     "InfectionSeedMethod",
-    "SeedInfectionsExponential",
+    "SeedInfectionsViaExpGrowth",
     "SeedInfectionsFromVec",
     "SeedInfectionsZeroPad",
     "InfectionSeedingProcess",

--- a/model/src/pyrenew/latent/__init__.py
+++ b/model/src/pyrenew/latent/__init__.py
@@ -10,8 +10,8 @@ from pyrenew.latent.infection_functions import (
 )
 from pyrenew.latent.infection_seeding_method import (
     InfectionSeedMethod,
+    SeedInfectionsExponentialGrowth,
     SeedInfectionsFromVec,
-    SeedInfectionsViaExpGrowth,
     SeedInfectionsZeroPad,
 )
 from pyrenew.latent.infection_seeding_process import InfectionSeedingProcess
@@ -25,7 +25,7 @@ __all__ = [
     "compute_infections_from_rt",
     "compute_infections_from_rt_with_feedback",
     "InfectionSeedMethod",
-    "SeedInfectionsViaExpGrowth",
+    "SeedInfectionsExponentialGrowth",
     "SeedInfectionsFromVec",
     "SeedInfectionsZeroPad",
     "InfectionSeedingProcess",

--- a/model/src/pyrenew/latent/infection_seeding_method.py
+++ b/model/src/pyrenew/latent/infection_seeding_method.py
@@ -120,7 +120,7 @@ class SeedInfectionsFromVec(InfectionSeedMethod):
         return jnp.array(I_pre_seed)
 
 
-class SeedInfectionsViaExpGrowth(InfectionSeedMethod):
+class SeedInfectionsExponentialGrowth(InfectionSeedMethod):
     r"""Generate seed infections according to exponential growth.
 
     Notes
@@ -142,7 +142,7 @@ class SeedInfectionsViaExpGrowth(InfectionSeedMethod):
         rate: RandomVariable,
         t_pre_seed: int | None = None,
     ):
-        """Default constructor for the ``SeedInfectionsViaExpGrowth`` class.
+        """Default constructor for the ``SeedInfectionsExponentialGrowth`` class.
 
         Parameters
         ----------

--- a/model/src/pyrenew/latent/infection_seeding_method.py
+++ b/model/src/pyrenew/latent/infection_seeding_method.py
@@ -120,7 +120,7 @@ class SeedInfectionsFromVec(InfectionSeedMethod):
         return jnp.array(I_pre_seed)
 
 
-class SeedInfectionsExponential(InfectionSeedMethod):
+class SeedInfectionsViaExpGrowth(InfectionSeedMethod):
     r"""Generate seed infections according to exponential growth.
 
     Notes
@@ -142,7 +142,7 @@ class SeedInfectionsExponential(InfectionSeedMethod):
         rate: RandomVariable,
         t_pre_seed: int | None = None,
     ):
-        """Default constructor for the ``SeedInfectionsExponential`` class.
+        """Default constructor for the ``SeedInfectionsViaExpGrowth`` class.
 
         Parameters
         ----------

--- a/model/src/test/test_infection_seeding_method.py
+++ b/model/src/test/test_infection_seeding_method.py
@@ -4,14 +4,14 @@ import numpy.testing as testing
 import pytest
 from pyrenew.deterministic import DeterministicVariable
 from pyrenew.latent import (
+    SeedInfectionsExponentialGrowth,
     SeedInfectionsFromVec,
-    SeedInfectionsViaExpGrowth,
     SeedInfectionsZeroPad,
 )
 
 
 def test_seed_infections_exponential():
-    """Check that the SeedInfectionsViaExpGrowth class generates the correct number of infections at each time point."""
+    """Check that the SeedInfectionsExponentialGrowth class generates the correct number of infections at each time point."""
     n_timepoints = 10
     rate_RV = DeterministicVariable(0.5, name="rate_RV")
     I_pre_seed_RV = DeterministicVariable(10.0, name="I_pre_seed_RV")
@@ -20,7 +20,7 @@ def test_seed_infections_exponential():
     (I_pre_seed,) = I_pre_seed_RV.sample()
     (rate,) = rate_RV.sample()
 
-    infections_default_t_pre_seed = SeedInfectionsViaExpGrowth(
+    infections_default_t_pre_seed = SeedInfectionsExponentialGrowth(
         n_timepoints, rate=rate_RV
     ).seed_infections(I_pre_seed)
     infections_default_t_pre_seed_manual = I_pre_seed * np.exp(
@@ -37,7 +37,7 @@ def test_seed_infections_exponential():
     # test for failure with non-scalar rate or I_pre_seed
     rate_RV_2 = DeterministicVariable(np.array([0.5, 0.5]), name="rate_RV")
     with pytest.raises(ValueError):
-        SeedInfectionsViaExpGrowth(
+        SeedInfectionsExponentialGrowth(
             n_timepoints, rate=rate_RV_2
         ).seed_infections(I_pre_seed)
 
@@ -47,13 +47,13 @@ def test_seed_infections_exponential():
     (I_pre_seed_2,) = I_pre_seed_RV_2.sample()
 
     with pytest.raises(ValueError):
-        SeedInfectionsViaExpGrowth(n_timepoints, rate=rate_RV).seed_infections(
-            I_pre_seed_2
-        )
+        SeedInfectionsExponentialGrowth(
+            n_timepoints, rate=rate_RV
+        ).seed_infections(I_pre_seed_2)
 
     # test non-default t_pre_seed
     t_pre_seed = 6
-    infections_custom_t_pre_seed = SeedInfectionsViaExpGrowth(
+    infections_custom_t_pre_seed = SeedInfectionsExponentialGrowth(
         n_timepoints, rate=rate_RV, t_pre_seed=t_pre_seed
     ).seed_infections(I_pre_seed)
     infections_custom_t_pre_seed_manual = I_pre_seed * np.exp(

--- a/model/src/test/test_infection_seeding_method.py
+++ b/model/src/test/test_infection_seeding_method.py
@@ -4,14 +4,14 @@ import numpy.testing as testing
 import pytest
 from pyrenew.deterministic import DeterministicVariable
 from pyrenew.latent import (
-    SeedInfectionsExponential,
     SeedInfectionsFromVec,
+    SeedInfectionsViaExpGrowth,
     SeedInfectionsZeroPad,
 )
 
 
 def test_seed_infections_exponential():
-    """Check that the SeedInfectionsExponential class generates the correct number of infections at each time point."""
+    """Check that the SeedInfectionsViaExpGrowth class generates the correct number of infections at each time point."""
     n_timepoints = 10
     rate_RV = DeterministicVariable(0.5, name="rate_RV")
     I_pre_seed_RV = DeterministicVariable(10.0, name="I_pre_seed_RV")
@@ -20,7 +20,7 @@ def test_seed_infections_exponential():
     (I_pre_seed,) = I_pre_seed_RV.sample()
     (rate,) = rate_RV.sample()
 
-    infections_default_t_pre_seed = SeedInfectionsExponential(
+    infections_default_t_pre_seed = SeedInfectionsViaExpGrowth(
         n_timepoints, rate=rate_RV
     ).seed_infections(I_pre_seed)
     infections_default_t_pre_seed_manual = I_pre_seed * np.exp(
@@ -37,7 +37,7 @@ def test_seed_infections_exponential():
     # test for failure with non-scalar rate or I_pre_seed
     rate_RV_2 = DeterministicVariable(np.array([0.5, 0.5]), name="rate_RV")
     with pytest.raises(ValueError):
-        SeedInfectionsExponential(
+        SeedInfectionsViaExpGrowth(
             n_timepoints, rate=rate_RV_2
         ).seed_infections(I_pre_seed)
 
@@ -47,13 +47,13 @@ def test_seed_infections_exponential():
     (I_pre_seed_2,) = I_pre_seed_RV_2.sample()
 
     with pytest.raises(ValueError):
-        SeedInfectionsExponential(n_timepoints, rate=rate_RV).seed_infections(
+        SeedInfectionsViaExpGrowth(n_timepoints, rate=rate_RV).seed_infections(
             I_pre_seed_2
         )
 
     # test non-default t_pre_seed
     t_pre_seed = 6
-    infections_custom_t_pre_seed = SeedInfectionsExponential(
+    infections_custom_t_pre_seed = SeedInfectionsViaExpGrowth(
         n_timepoints, rate=rate_RV, t_pre_seed=t_pre_seed
     ).seed_infections(I_pre_seed)
     infections_custom_t_pre_seed_manual = I_pre_seed * np.exp(

--- a/model/src/test/test_infection_seeding_process.py
+++ b/model/src/test/test_infection_seeding_process.py
@@ -6,8 +6,8 @@ import pytest
 from pyrenew.deterministic import DeterministicVariable
 from pyrenew.latent import (
     InfectionSeedingProcess,
+    SeedInfectionsExponentialGrowth,
     SeedInfectionsFromVec,
-    SeedInfectionsViaExpGrowth,
     SeedInfectionsZeroPad,
 )
 from pyrenew.metaclass import DistributionalRV
@@ -27,7 +27,7 @@ def test_infection_seeding_process():
     exp_model = InfectionSeedingProcess(
         "exp_model",
         DistributionalRV(dist=dist.LogNormal(0, 1), name="I0"),
-        SeedInfectionsViaExpGrowth(
+        SeedInfectionsExponentialGrowth(
             n_timepoints, DeterministicVariable(0.5, name="rate")
         ),
         t_unit=1,

--- a/model/src/test/test_infection_seeding_process.py
+++ b/model/src/test/test_infection_seeding_process.py
@@ -6,8 +6,8 @@ import pytest
 from pyrenew.deterministic import DeterministicVariable
 from pyrenew.latent import (
     InfectionSeedingProcess,
-    SeedInfectionsExponential,
     SeedInfectionsFromVec,
+    SeedInfectionsViaExpGrowth,
     SeedInfectionsZeroPad,
 )
 from pyrenew.metaclass import DistributionalRV
@@ -27,7 +27,7 @@ def test_infection_seeding_process():
     exp_model = InfectionSeedingProcess(
         "exp_model",
         DistributionalRV(dist=dist.LogNormal(0, 1), name="I0"),
-        SeedInfectionsExponential(
+        SeedInfectionsViaExpGrowth(
             n_timepoints, DeterministicVariable(0.5, name="rate")
         ),
         t_unit=1,


### PR DESCRIPTION
This PR seeks to rename the class `SeedInfectionsExponential` so that users of MSR do not take _exponential_ here to mean involving Exponential distributions but instead take _exponential_ to mean relating to an exponential growth model.