### PR TITLE
sample multiple chain sequentially to avoid warning

### DIFF
--- a/model/docs/basic_renewal_model.qmd
+++ b/model/docs/basic_renewal_model.qmd
@@ -214,7 +214,7 @@ model1.run(
     num_samples=1000,
     data_observed_infections=sim_data.observed_infections,
     rng_key=jax.random.PRNGKey(54),
-    mcmc_args=dict(progress_bar=False, num_chains=2),
+    mcmc_args=dict(progress_bar=False, num_chains=2, chain_method="sequential"),
 )
 ```
 
@@ -335,9 +335,7 @@ az.plot_hdi(
 )
 
 # Add mean of the posterior to the figure
-mean_latent_infection = np.mean(
-    idata.posterior["all_latent_infections"], axis=1
-)
+mean_latent_infection = np.mean(idata.posterior["all_latent_infections"], axis=1)
 axes.plot(x_data, mean_latent_infection[0], color="C0", label="Mean")
 axes.legend()
 axes.set_title("Posterior Latent Infections", fontsize=10)


### PR DESCRIPTION
Added `chain_method="sequential"` to tutorials while sampling multiple chains to avoid warning.

Note, only made changes in basic renewal model in this PR, hospital admissions model was already modified previously.