### PR TITLE
add ipywidgets as dependency to remove warning

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -17,6 +17,7 @@ polars = "^0.20.16"
 matplotlib = "^3.8.3"
 sphinx-autodoc-typehints = "^2.1.0"
 sphinx-book-theme = "^1.1.2"
+ipywidgets = "^8.1.3"
 
 [tool.numpydoc_validation]
 checks = [

--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -18,6 +18,7 @@ polars = "^0.20.16"
 pillow = "^10.3.0" # See #56 on CDCgov/multisignal-epi-inference
 nbconvert = "^7.16.4"
 pytest-mpl = "^0.17.0"
+ipywidgets = "^8.1.3"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
Added `ipywidgets` to pyproject.toml to aviod the following warning message in the tutorial.
```{bash}
/home/runner/.cache/pypoetry/virtualenvs/pyrenew-ay_vsbmF-py3.12/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
  from .autonotebook import tqdm as notebook_tqdm
```