### PR TITLE
Avoid None encountered in jnp array warning

### DIFF
--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -268,6 +268,7 @@ az.plot_trace(
     coords={"Rt_dim_0": np.arange(10)},
     compact=False,
 )
+plt.show()
 ```
 
 
@@ -305,6 +306,7 @@ axes.legend()
 axes.set_title("Posterior Effective Reproduction Number", fontsize=10)
 axes.set_xlabel("Time", fontsize=10)
 axes.set_ylabel("$R_t$", fontsize=10)
+plt.show()
 ```
 
 and latent infections:
@@ -345,4 +347,5 @@ axes.legend()
 axes.set_title("Posterior Latent Infections", fontsize=10)
 axes.set_xlabel("Time", fontsize=10)
 axes.set_ylabel("Latent Infections", fontsize=10)
+plt.show()
 ```

--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -268,7 +268,6 @@ az.plot_trace(
     coords={"Rt_dim_0": np.arange(10)},
     compact=False,
 )
-plt.show()
 ```
 
 
@@ -306,7 +305,6 @@ axes.legend()
 axes.set_title("Posterior Effective Reproduction Number", fontsize=10)
 axes.set_xlabel("Time", fontsize=10)
 axes.set_ylabel("$R_t$", fontsize=10)
-plt.show()
 ```
 
 and latent infections:
@@ -347,5 +345,4 @@ axes.legend()
 axes.set_title("Posterior Latent Infections", fontsize=10)
 axes.set_xlabel("Time", fontsize=10)
 axes.set_ylabel("Latent Infections", fontsize=10)
-plt.show()
 ```

--- a/model/src/pyrenew/model/rtinfectionsrenewalmodel.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewalmodel.py
@@ -224,12 +224,14 @@ class RtInfectionsRenewalModel(Model):
         )
         npro.deterministic("all_latent_infections", all_latent_infections)
 
-        observed_infections = au.pad_x_to_match_y(
-            observed_infections,
-            all_latent_infections,
-            jnp.nan,
-            pad_direction="start",
-        )
+        if observed_infections is not None:
+            observed_infections = au.pad_x_to_match_y(
+                observed_infections,
+                all_latent_infections,
+                jnp.nan,
+                pad_direction="start",
+            )
+
         Rt = au.pad_x_to_match_y(
             Rt,
             all_latent_infections,


### PR DESCRIPTION
Add condition for padding `observed_infection` in `rtinfectionsrenewalmodel.py` to avoid padding the `observed_infection` when the `infection_obs_process_rv` is `None` and prevent the `None` encountered warning.