### PR TITLE
change Model.run so parameters always get passed

### DIFF
--- a/model/src/pyrenew/metaclass.py
+++ b/model/src/pyrenew/metaclass.py
@@ -425,13 +425,12 @@ class Model(metaclass=ABCMeta):
         None
         """
 
-        if self.mcmc is None:
-            self._init_model(
-                num_warmup=num_warmup,
-                num_samples=num_samples,
-                nuts_args=nuts_args,
-                mcmc_args=mcmc_args,
-            )
+        self._init_model(
+            num_warmup=num_warmup,
+            num_samples=num_samples,
+            nuts_args=nuts_args,
+            mcmc_args=mcmc_args,
+        )
         if rng_key is None:
             rand_int = np.random.randint(
                 np.iinfo(np.int64).min, np.iinfo(np.int64).max


### PR DESCRIPTION
Previously, parameters passed would get ignored on calls to `run()` after the first, since `run` did not re-create the `MCMC` and `NUTS` objects. Since this creation operation is not expensive, I think they should just be re-created at each `run()` call