### PR TITLE
Set Default `eps` Value To `jnp.finfo(float).eps` And Test

### DIFF
--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 from jax.typing import ArrayLike
@@ -16,7 +17,7 @@ class NegativeBinomialObservation(RandomVariable):
         self,
         name: str,
         concentration_rv: RandomVariable,
-        eps: float = 1e-10,
+        eps: float = jnp.finfo(float).eps,
     ) -> None:
         """
         Default constructor
@@ -34,7 +35,7 @@ class NegativeBinomialObservation(RandomVariable):
             of dispersion.
         eps : float, optional
             Small value to add to the predicted mean to prevent numerical
-            instability. Defaults to 1e-10.
+            instability. Defaults to `jnp.finfo(float).eps` (previously 1e-10).
 
         Returns
         -------

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -90,9 +90,7 @@ class NegativeBinomialObservation(RandomVariable):
         """
         concentration, *_ = self.concentration_rv.sample()
 
-        clipped_mu = jnp.clip(
-            mu + self.eps, min=jnp.finfo(float).eps, max=jnp.inf
-        )
+        clipped_mu = jnp.clip(mu, min=self.eps, max=jnp.inf)
 
         negative_binomial_sample = numpyro.sample(
             name=self.name,

--- a/model/src/pyrenew/observation/negativebinomial.py
+++ b/model/src/pyrenew/observation/negativebinomial.py
@@ -90,10 +90,14 @@ class NegativeBinomialObservation(RandomVariable):
         """
         concentration, *_ = self.concentration_rv.sample()
 
+        clipped_mu = jnp.clip(
+            mu + self.eps, min=jnp.finfo(float).eps, max=jnp.inf
+        )
+
         negative_binomial_sample = numpyro.sample(
             name=self.name,
             fn=dist.NegativeBinomial2(
-                mean=mu + self.eps,
+                mean=clipped_mu,
                 concentration=concentration.value,
             ),
             obs=obs,

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -68,9 +68,13 @@ class PoissonObservation(RandomVariable):
         tuple
         """
 
+        clipped_mu = jnp.clip(
+            mu + self.eps, min=jnp.finfo(float).eps, max=jnp.inf
+        )
+
         poisson_sample = numpyro.sample(
             name=self.name,
-            fn=dist.Poisson(rate=mu + self.eps),
+            fn=dist.Poisson(rate=clipped_mu),
             obs=obs,
         )
         return (

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -68,9 +68,7 @@ class PoissonObservation(RandomVariable):
         tuple
         """
 
-        clipped_mu = jnp.clip(
-            mu + self.eps, min=jnp.finfo(float).eps, max=jnp.inf
-        )
+        clipped_mu = jnp.clip(mu, min=self.eps, max=jnp.inf)
 
         poisson_sample = numpyro.sample(
             name=self.name,

--- a/model/src/pyrenew/observation/poisson.py
+++ b/model/src/pyrenew/observation/poisson.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 from jax.typing import ArrayLike
@@ -17,7 +18,7 @@ class PoissonObservation(RandomVariable):
     def __init__(
         self,
         name: str,
-        eps: float = 1e-8,
+        eps: float = jnp.finfo(float).eps,
     ) -> None:
         """
         Default Constructor
@@ -28,7 +29,7 @@ class PoissonObservation(RandomVariable):
             Passed to numpyro.sample.
         eps : float, optional
             Small value added to the rate parameter to avoid zero values.
-            Defaults to 1e-8.
+            Defaults to `jnp.finfo(float).eps` (previously 1e-8).
 
         Returns
         -------

--- a/model/src/test/test_observation_negativebinom.py
+++ b/model/src/test/test_observation_negativebinom.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
-import jax.numpy as jnp
 import numpy as np
 import numpy.testing as testing
 import numpyro
@@ -62,30 +61,47 @@ def test_negativebinom_random_obs():
     )
 
 
-def test_negativebinom_clipping():
-    """
-    Check that the clipping of the mean parameter works correctly.
-    """
+# def test_negativebinom_naive_vs_clipped():
+#     """
+#     Test that demonstrates the failure of the naive method (eps=0)
+#     and the success of the method with clipping or small eps.
+#     """
 
-    negb = NegativeBinomialObservation(
-        "negbinom_rv",
-        concentration_rv=DeterministicVariable(name="concentration", value=10),
-    )
 
-    small_mu = 1e-10
-    expected_clipped_mu = jnp.clip(
-        small_mu + jnp.finfo(float).eps, min=jnp.finfo(float).eps, max=jnp.inf
-    )
+#     concentration_rv = DeterministicVariable(name="concentration", value=10)
 
-    with numpyro.handlers.seed(rng_seed=223):
-        sim_nb = negb(mu=small_mu)
+#     negb_naive = NegativeBinomialObservation(
+#         "negbinom_rv_naive",
+#         concentration_rv=concentration_rv,
+#         eps=0.0
+#     )
 
-    assert isinstance(sim_nb, tuple)
-    assert isinstance(sim_nb[0].value, ArrayLike)
+#     negb_clipped = NegativeBinomialObservation(
+#         "negbinom_rv_clipped",
+#         concentration_rv=concentration_rv,
+#         eps=jnp.finfo(float).eps
+#     )
 
-    mean_sample_value = jnp.mean(sim_nb[0].value)
-    testing.assert_array_almost_equal(
-        mean_sample_value,
-        expected_clipped_mu,
-        decimal=5,
-    )
+#     naive_failed = False
+#     try:
+#         with numpyro.handlers.seed(rng_seed=223):
+#             negb_naive_sample = negb_naive(mu=0.0)
+#     except Exception as e:
+#         naive_failed = True
+#         print(f"Naive method failed as expected: {e}")
+#     assert naive_failed, "Naive method did not fail as expected."
+
+#     clipped_failed = False
+#     try:
+#         with numpyro.handlers.seed(rng_seed=223):
+#             negb_clipped_sample = negb_clipped(mu=0.0)
+#     except Exception as e:
+#         clipped_failed = True
+#         print(f"Clipped method failed unexpectedly: {e}")
+#     assert not clipped_failed, "Clipped method failed unexpectedly."
+
+#     assert isinstance(negb_clipped_sample, tuple)
+#     assert isinstance(negb_clipped_sample[0].value, ArrayLike)
+
+#     mean_sample_value = jnp.mean(negb_clipped_sample[0].value)
+#     assert mean_sample_value >= jnp.finfo(float).eps, "Clipped sample mean is unexpectedly low."

--- a/model/src/test/test_observation_negativebinom.py
+++ b/model/src/test/test_observation_negativebinom.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # numpydoc ignore=GL08
 
+import jax.numpy as jnp
 import numpy as np
 import numpy.testing as testing
 import numpyro
@@ -58,4 +59,33 @@ def test_negativebinom_random_obs():
         np.mean(sim_nb1[0].value),
         np.mean(sim_nb2[0].value),
         decimal=1,
+    )
+
+
+def test_negativebinom_clipping():
+    """
+    Check that the clipping of the mean parameter works correctly.
+    """
+
+    negb = NegativeBinomialObservation(
+        "negbinom_rv",
+        concentration_rv=DeterministicVariable(name="concentration", value=10),
+    )
+
+    small_mu = 1e-10
+    expected_clipped_mu = jnp.clip(
+        small_mu + jnp.finfo(float).eps, min=jnp.finfo(float).eps, max=jnp.inf
+    )
+
+    with numpyro.handlers.seed(rng_seed=223):
+        sim_nb = negb(mu=small_mu)
+
+    assert isinstance(sim_nb, tuple)
+    assert isinstance(sim_nb[0].value, ArrayLike)
+
+    mean_sample_value = jnp.mean(sim_nb[0].value)
+    testing.assert_array_almost_equal(
+        mean_sample_value,
+        expected_clipped_mu,
+        decimal=5,
     )

--- a/model/src/test/test_observation_poisson.py
+++ b/model/src/test/test_observation_poisson.py
@@ -20,3 +20,26 @@ def test_poisson_obs():
         sim_pois, *_ = pois(mu=rates)
 
     testing.assert_array_equal(sim_pois.value, jnp.ceil(sim_pois.value))
+
+
+def test_poisson_clipping():
+    """
+    Check that the clipping of the mean parameter works correctly.
+    """
+
+    pois = PoissonObservation(name="pois_rv")
+
+    small_mu = 1e-10
+    expected_clipped_mu = jnp.clip(
+        small_mu + jnp.finfo(float).eps, min=jnp.finfo(float).eps, max=jnp.inf
+    )
+
+    with numpyro.handlers.seed(rng_seed=223):
+        sim_pois, *_ = pois(mu=small_mu)
+
+    mean_sample_value = jnp.mean(sim_pois.value)
+    testing.assert_array_almost_equal(
+        mean_sample_value,
+        expected_clipped_mu,
+        decimal=5,
+    )

--- a/model/src/test/test_observation_poisson.py
+++ b/model/src/test/test_observation_poisson.py
@@ -10,7 +10,7 @@ from pyrenew.observation import PoissonObservation
 
 def test_poisson_obs():
     """
-    Check that an PoissonObservation can sample
+    Check that an PoissonObservation can sample.
     """
 
     pois = PoissonObservation("rv")
@@ -20,3 +20,28 @@ def test_poisson_obs():
         sim_pois, *_ = pois(mu=rates)
 
     testing.assert_array_equal(sim_pois, jnp.ceil(sim_pois))
+
+
+def test_poisson_obs_eps():
+    """
+    Check that `eps` default for PoissonObservation does not
+    fail when `eps = 0` does.
+    """
+
+    pois_eps_default = PoissonObservation(name="rv", eps=jnp.finfo(float).eps)
+    pois_eps_zero = PoissonObservation(name="rv", eps=0.0)
+
+    rates = np.random.randint(1, 5, size=10)
+
+    # eps = jnp.finfo(float).eps does not fail
+    with numpyro.handlers.seed(rng_seed=223):
+        sim_pois_eps_default, *_ = pois_eps_default(mu=rates)
+    testing.assert_array_equal(
+        sim_pois_eps_default, jnp.ceil(sim_pois_eps_default)
+    )
+
+    # esp = 0.0 fails?
+    # with pytest.raises(AssertionError):
+    with numpyro.handlers.seed(rng_seed=223):
+        sim_pois_eps_zero, *_ = pois_eps_zero(mu=rates)
+    testing.assert_array_equal(sim_pois_eps_zero, jnp.ceil(sim_pois_eps_zero))

--- a/model/src/test/test_rtperiodicdiff.py
+++ b/model/src/test/test_rtperiodicdiff.py
@@ -7,7 +7,7 @@ import numpy as np
 import numpyro
 from jax import lax
 from jax.typing import ArrayLike
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 from pyrenew.deterministic import DeterministicVariable
 from pyrenew.process import RtWeeklyDiffProcess
 
@@ -64,7 +64,7 @@ def test_rtweeklydiff() -> None:
 
     rtwd = RtWeeklyDiffProcess(**params)
 
-    with numpyro.handlers.seed(rng_seed=15):
+    with numpyro.handlers.seed(rng_seed=121):
         rt = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -78,7 +78,7 @@ def test_rtweeklydiff() -> None:
     # Checking start off a different day of the week
     params["offset"] = 5
     rtwd = RtWeeklyDiffProcess(**params)
-    with numpyro.handlers.seed(rng_seed=15):
+    with numpyro.handlers.seed(rng_seed=121):
         rt2 = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -110,7 +110,7 @@ def test_rtweeklydiff_no_autoregressive() -> None:
     rtwd = RtWeeklyDiffProcess(**params)
 
     duration = 1000
-    with numpyro.handlers.seed(rng_seed=20):
+    with numpyro.handlers.seed(rng_seed=323):
         rt = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -158,7 +158,7 @@ def test_rtweeklydiff_manual_reconstruction() -> None:
         log_seed=params["log_rt_prior"]()[0], sd=noise, b=b
     )
 
-    assert_array_equal(ans0, ans1)
+    assert_array_almost_equal(ans0, ans1)
 
     return None
 
@@ -180,7 +180,7 @@ def test_rtperiodicdiff_smallsample():
 
     rtwd = RtWeeklyDiffProcess(**params)
 
-    with numpyro.handlers.seed(rng_seed=21):
+    with numpyro.handlers.seed(rng_seed=223):
         rt = rtwd(duration=6).rt
 
     # Checking that the shape of the sampled Rt is correct

--- a/model/src/test/test_rtperiodicdiff.py
+++ b/model/src/test/test_rtperiodicdiff.py
@@ -64,7 +64,7 @@ def test_rtweeklydiff() -> None:
 
     rtwd = RtWeeklyDiffProcess(**params)
 
-    with numpyro.handlers.seed(rng_seed=121):
+    with numpyro.handlers.seed(rng_seed=1234):
         rt = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -78,7 +78,7 @@ def test_rtweeklydiff() -> None:
     # Checking start off a different day of the week
     params["offset"] = 5
     rtwd = RtWeeklyDiffProcess(**params)
-    with numpyro.handlers.seed(rng_seed=121):
+    with numpyro.handlers.seed(rng_seed=1234):
         rt2 = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -110,7 +110,7 @@ def test_rtweeklydiff_no_autoregressive() -> None:
     rtwd = RtWeeklyDiffProcess(**params)
 
     duration = 1000
-    with numpyro.handlers.seed(rng_seed=323):
+    with numpyro.handlers.seed(rng_seed=1234):
         rt = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -180,7 +180,7 @@ def test_rtperiodicdiff_smallsample():
 
     rtwd = RtWeeklyDiffProcess(**params)
 
-    with numpyro.handlers.seed(rng_seed=223):
+    with numpyro.handlers.seed(rng_seed=1234):
         rt = rtwd(duration=6).rt
 
     # Checking that the shape of the sampled Rt is correct

--- a/model/src/test/test_rtperiodicdiff.py
+++ b/model/src/test/test_rtperiodicdiff.py
@@ -64,7 +64,7 @@ def test_rtweeklydiff() -> None:
 
     rtwd = RtWeeklyDiffProcess(**params)
 
-    with numpyro.handlers.seed(rng_seed=1234):
+    with numpyro.handlers.seed(rng_seed=15):
         rt = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -78,7 +78,7 @@ def test_rtweeklydiff() -> None:
     # Checking start off a different day of the week
     params["offset"] = 5
     rtwd = RtWeeklyDiffProcess(**params)
-    with numpyro.handlers.seed(rng_seed=1234):
+    with numpyro.handlers.seed(rng_seed=15):
         rt2 = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -110,7 +110,7 @@ def test_rtweeklydiff_no_autoregressive() -> None:
     rtwd = RtWeeklyDiffProcess(**params)
 
     duration = 1000
-    with numpyro.handlers.seed(rng_seed=1234):
+    with numpyro.handlers.seed(rng_seed=20):
         rt = rtwd(duration=duration).rt
 
     # Checking that the shape of the sampled Rt is correct
@@ -180,7 +180,7 @@ def test_rtperiodicdiff_smallsample():
 
     rtwd = RtWeeklyDiffProcess(**params)
 
-    with numpyro.handlers.seed(rng_seed=1234):
+    with numpyro.handlers.seed(rng_seed=21):
         rt = rtwd(duration=6).rt
 
     # Checking that the shape of the sampled Rt is correct


### PR DESCRIPTION
Previously the defaults for the `eps` value in `dist.Poisson(rate=mu + self.eps)` and `fn=dist.NegativeBinomial2(mean=mu + self.eps, concentration=concentration)` were set to `1e-8` and `1e-10` respectively, but instead can be set to the machine float minimum (see [here](https://numpy.org/doc/stable/reference/generated/numpy.finfo.html)) via `jnp.finfo(float).eps`. This needs to be tested, however, to make sure the distribution implementations of Poisson and NegativeBinomial still function properly. 