### PR TITLE
Additional `seed` To `init` Changes

### DIFF
--- a/docs/source/tutorials/time.qmd
+++ b/docs/source/tutorials/time.qmd
@@ -20,7 +20,7 @@ The tuple `(t_unit, t_start)` can encode different types of time series data. Fo
 | Weekly starting on week two | 7               | 7                |
 | Daily starting on day 40 | 1               | 39               |
 | Biweekly starting on day 40 | 14              | 39               |
-| Daily, with the first observation starting five days before the model (as in the seeding process) | 1               | -5               |
+| Daily, with the first observation starting five days before the model (as in the initialization process) | 1               | -5               |
 
 
 ## How it relates to periodicity
@@ -37,7 +37,7 @@ With random variables possibly spanning different time scales, *e.g.*, weekly, d
 
 ### Array alignment
 
-Using `t_unit` and `t_start`, random variables should be able to align input and output data. For example, in the case of the `RtInfectionsRenewalModel()`, the computed values of `Rt` and `infections` are padded left with `nan` values to account for the seeding process. Instead, we expect to either pre-process the padding leveraging the `t_start` information of the involved variables or simplify the process via a function call that aligns the arrays. A possible implementation could be a method `align()` that takes a list of random variables and aligns them based on the `t_unit` and `t_start` information, e.g.:
+Using `t_unit` and `t_start`, random variables should be able to align input and output data. For example, in the case of the `RtInfectionsRenewalModel()`, the computed values of `Rt` and `infections` are padded left with `nan` values to account for the initialization process. Instead, we expect to either pre-process the padding leveraging the `t_start` information of the involved variables or simplify the process via a function call that aligns the arrays. A possible implementation could be a method `align()` that takes a list of random variables and aligns them based on the `t_unit` and `t_start` information, e.g.:
 
 ```python
 Rt_aligned, infections_aligned = align([Rt, infections])

--- a/model/src/pyrenew/latent/infection_initialization_method.py
+++ b/model/src/pyrenew/latent/infection_initialization_method.py
@@ -48,12 +48,12 @@ class InfectionInitializationMethod(metaclass=ABCMeta):
             )
 
     @abstractmethod
-    def seed_infections(self, I_pre_seed: ArrayLike):
+    def initialize_infections(self, I_pre_init: ArrayLike):
         """Generate the number of seeded infections at each time point.
 
         Parameters
         ----------
-        I_pre_seed : ArrayLike
+        I_pre_init : ArrayLike
             An array representing some number of latent infections to be used with the specified ``InfectionInitializationMethod``.
 
         Returns
@@ -62,8 +62,8 @@ class InfectionInitializationMethod(metaclass=ABCMeta):
             An array of length ``n_timepoints`` with the number of seeded infections at each time point.
         """
 
-    def __call__(self, I_pre_seed: ArrayLike):
-        return self.seed_infections(I_pre_seed)
+    def __call__(self, I_pre_init: ArrayLike):
+        return self.initialize_infections(I_pre_init)
 
 
 class InitializeInfectionsZeroPad(InfectionInitializationMethod):
@@ -73,12 +73,12 @@ class InitializeInfectionsZeroPad(InfectionInitializationMethod):
     zeros at the beginning of the time series.
     """
 
-    def seed_infections(self, I_pre_seed: ArrayLike):
+    def initialize_infections(self, I_pre_init: ArrayLike):
         """Pad the initial infections with zeros at the beginning of the time series.
 
         Parameters
         ----------
-        I_pre_seed : ArrayLike
+        I_pre_init : ArrayLike
             An array with seeded infections to be padded with zeros.
 
         Returns
@@ -86,24 +86,24 @@ class InitializeInfectionsZeroPad(InfectionInitializationMethod):
         ArrayLike
             An array of length ``n_timepoints`` with the number of seeded infections at each time point.
         """
-        if self.n_timepoints < I_pre_seed.size:
+        if self.n_timepoints < I_pre_init.size:
             raise ValueError(
-                "I_pre_seed must be no longer than n_timepoints. "
-                f"Got I_pre_seed of size {I_pre_seed.size} and "
+                "I_pre_init must be no longer than n_timepoints. "
+                f"Got I_pre_init of size {I_pre_init.size} and "
                 f" n_timepoints of size {self.n_timepoints}."
             )
-        return jnp.pad(I_pre_seed, (self.n_timepoints - I_pre_seed.size, 0))
+        return jnp.pad(I_pre_init, (self.n_timepoints - I_pre_init.size, 0))
 
 
 class InitializeInfectionsFromVec(InfectionInitializationMethod):
     """Create initial infections from a vector of infections."""
 
-    def seed_infections(self, I_pre_seed: ArrayLike):
+    def initialize_infections(self, I_pre_init: ArrayLike):
         """Create initial infections from a vector of infections.
 
         Parameters
         ----------
-        I_pre_seed : ArrayLike
+        I_pre_init : ArrayLike
             An array with the same length as ``n_timepoints`` to be used as the initial infections.
 
         Returns
@@ -111,13 +111,13 @@ class InitializeInfectionsFromVec(InfectionInitializationMethod):
         ArrayLike
             An array of length ``n_timepoints`` with the number of seeded infections at each time point.
         """
-        if I_pre_seed.size != self.n_timepoints:
+        if I_pre_init.size != self.n_timepoints:
             raise ValueError(
-                "I_pre_seed must have the same size as n_timepoints. "
-                f"Got I_pre_seed of size {I_pre_seed.size} "
+                "I_pre_init must have the same size as n_timepoints. "
+                f"Got I_pre_init of size {I_pre_init.size} "
                 f"and n_timepoints of size {self.n_timepoints}."
             )
-        return jnp.array(I_pre_seed)
+        return jnp.array(I_pre_init)
 
 
 class InitializeInfectionsExponentialGrowth(InfectionInitializationMethod):
@@ -129,10 +129,10 @@ class InitializeInfectionsExponentialGrowth(InfectionInitializationMethod):
 
     .. math:: I(t) = I_p \exp \left( r (t - t_p) \right)
 
-    Where :math:`I_p` is ``I_pre_seed``, :math:`r` is ``rate``, and :math:`t_p` is ``t_pre_seed``.
+    Where :math:`I_p` is ``I_pre_init``, :math:`r` is ``rate``, and :math:`t_p` is ``t_pre_init``.
     This ensures that :math:`I(t_p) = I_p`.
-    We default to ``t_pre_seed = n_timepoints - 1``, so that
-    ``I_pre_seed`` represents the number of incident infections immediately
+    We default to ``t_pre_init = n_timepoints - 1``, so that
+    ``I_pre_init`` represents the number of incident infections immediately
     before the renewal process begins.
     """
 
@@ -140,7 +140,7 @@ class InitializeInfectionsExponentialGrowth(InfectionInitializationMethod):
         self,
         n_timepoints: int,
         rate: RandomVariable,
-        t_pre_seed: int | None = None,
+        t_pre_init: int | None = None,
     ):
         """Default constructor for the ``InitializeInfectionsExponentialGrowth`` class.
 
@@ -150,37 +150,37 @@ class InitializeInfectionsExponentialGrowth(InfectionInitializationMethod):
             the number of time points to generate initial infections for
         rate : RandomVariable
             A random variable representing the rate of exponential growth
-        t_pre_seed : int | None, optional
-             The time point whose number of infections is described by ``I_pre_seed``. Defaults to ``n_timepoints - 1``.
+        t_pre_init : int | None, optional
+             The time point whose number of infections is described by ``I_pre_init``. Defaults to ``n_timepoints - 1``.
         """
         super().__init__(n_timepoints)
         self.rate = rate
-        if t_pre_seed is None:
-            t_pre_seed = n_timepoints - 1
-        self.t_pre_seed = t_pre_seed
+        if t_pre_init is None:
+            t_pre_init = n_timepoints - 1
+        self.t_pre_init = t_pre_init
 
-    def seed_infections(self, I_pre_seed: ArrayLike):
+    def initialize_infections(self, I_pre_init: ArrayLike):
         """Generate initial infections according to exponential growth.
 
         Parameters
         ----------
-        I_pre_seed : ArrayLike
-            An array of size 1 representing the number of infections at time ``t_pre_seed``.
+        I_pre_init : ArrayLike
+            An array of size 1 representing the number of infections at time ``t_pre_init``.
 
         Returns
         -------
         ArrayLike
             An array of length ``n_timepoints`` with the number of seeded infections at each time point.
         """
-        if I_pre_seed.size != 1:
+        if I_pre_init.size != 1:
             raise ValueError(
-                f"I_pre_seed must be an array of size 1. Got size {I_pre_seed.size}."
+                f"I_pre_init must be an array of size 1. Got size {I_pre_init.size}."
             )
         (rate,) = self.rate()
         if rate.size != 1:
             raise ValueError(
                 f"rate must be an array of size 1. Got size {rate.size}."
             )
-        return I_pre_seed * jnp.exp(
-            rate * (jnp.arange(self.n_timepoints) - self.t_pre_seed)
+        return I_pre_init * jnp.exp(
+            rate * (jnp.arange(self.n_timepoints) - self.t_pre_init)
         )

--- a/model/src/pyrenew/latent/infection_initialization_method.py
+++ b/model/src/pyrenew/latent/infection_initialization_method.py
@@ -8,7 +8,7 @@ from pyrenew.metaclass import RandomVariable
 
 
 class InfectionInitializationMethod(metaclass=ABCMeta):
-    """Method for seeding initial infections in a renewal process."""
+    """Method for initializing infections in a renewal process."""
 
     def __init__(self, n_timepoints: int):
         """Default constructor for the ``InfectionInitializationMethod`` class.
@@ -49,7 +49,7 @@ class InfectionInitializationMethod(metaclass=ABCMeta):
 
     @abstractmethod
     def initialize_infections(self, I_pre_init: ArrayLike):
-        """Generate the number of seeded infections at each time point.
+        """Generate the number of initialized infections at each time point.
 
         Parameters
         ----------
@@ -59,7 +59,7 @@ class InfectionInitializationMethod(metaclass=ABCMeta):
         Returns
         -------
         ArrayLike
-            An array of length ``n_timepoints`` with the number of seeded infections at each time point.
+            An array of length ``n_timepoints`` with the number of initialized infections at each time point.
         """
 
     def __call__(self, I_pre_init: ArrayLike):
@@ -79,12 +79,12 @@ class InitializeInfectionsZeroPad(InfectionInitializationMethod):
         Parameters
         ----------
         I_pre_init : ArrayLike
-            An array with seeded infections to be padded with zeros.
+            An array with initialized infections to be padded with zeros.
 
         Returns
         -------
         ArrayLike
-            An array of length ``n_timepoints`` with the number of seeded infections at each time point.
+            An array of length ``n_timepoints`` with the number of initialized infections at each time point.
         """
         if self.n_timepoints < I_pre_init.size:
             raise ValueError(
@@ -109,7 +109,7 @@ class InitializeInfectionsFromVec(InfectionInitializationMethod):
         Returns
         -------
         ArrayLike
-            An array of length ``n_timepoints`` with the number of seeded infections at each time point.
+            An array of length ``n_timepoints`` with the number of initialized infections at each time point.
         """
         if I_pre_init.size != self.n_timepoints:
             raise ValueError(
@@ -170,7 +170,7 @@ class InitializeInfectionsExponentialGrowth(InfectionInitializationMethod):
         Returns
         -------
         ArrayLike
-            An array of length ``n_timepoints`` with the number of seeded infections at each time point.
+            An array of length ``n_timepoints`` with the number of initialized infections at each time point.
         """
         if I_pre_init.size != 1:
             raise ValueError(

--- a/model/src/pyrenew/latent/infection_initialization_process.py
+++ b/model/src/pyrenew/latent/infection_initialization_process.py
@@ -96,7 +96,7 @@ class InfectionInitializationProcess(RandomVariable):
             a tuple where the only element is an array with the number of seeded infections at each time point.
         """
         (I_pre_init,) = self.I_pre_init_rv()
-        infection_seeding = self.infection_init_method(I_pre_init)
-        npro.deterministic(self.name, infection_seeding)
+        infection_initialization = self.infection_init_method(I_pre_init)
+        npro.deterministic(self.name, infection_initialization)
 
-        return (infection_seeding,)
+        return (infection_initialization,)

--- a/model/src/pyrenew/latent/infection_initialization_process.py
+++ b/model/src/pyrenew/latent/infection_initialization_process.py
@@ -93,7 +93,7 @@ class InfectionInitializationProcess(RandomVariable):
         Returns
         -------
         tuple
-            a tuple where the only element is an array with the number of seeded infections at each time point.
+            a tuple where the only element is an array with the number of initialized infections at each time point.
         """
         (I_pre_init,) = self.I_pre_init_rv()
         infection_initialization = self.infection_init_method(I_pre_init)

--- a/model/src/pyrenew/latent/infection_initialization_process.py
+++ b/model/src/pyrenew/latent/infection_initialization_process.py
@@ -13,8 +13,8 @@ class InfectionInitializationProcess(RandomVariable):
     def __init__(
         self,
         name,
-        I_pre_seed_rv: RandomVariable,
-        infection_seed_method: InfectionInitializationMethod,
+        I_pre_init_rv: RandomVariable,
+        infection_init_method: InfectionInitializationMethod,
         t_unit: int,
         t_start: int | None = None,
     ) -> None:
@@ -24,32 +24,32 @@ class InfectionInitializationProcess(RandomVariable):
         ----------
         name : str
             A name to assign to the RandomVariable.
-        I_pre_seed_rv : RandomVariable
-            A RandomVariable representing the number of infections that occur at some time before the renewal process begins. Each `infection_seed_method` uses this random variable in different ways.
-        infection_seed_method : InfectionInitializationMethod
+        I_pre_init_rv : RandomVariable
+            A RandomVariable representing the number of infections that occur at some time before the renewal process begins. Each `infection_init_method` uses this random variable in different ways.
+        infection_init_method : InfectionInitializationMethod
             An `InfectionInitializationMethod` that generates the initial infections for the renewal process.
         t_unit : int
             The unit of time for the time series passed to `RandomVariable.set_timeseries`.
         t_start : int, optional
-            The relative starting time of the time series. If `None`, the relative starting time is set to `-infection_seed_method.n_timepoints`.
+            The relative starting time of the time series. If `None`, the relative starting time is set to `-infection_init_method.n_timepoints`.
 
         Notes
         -----
-        The relative starting time of the time series (`t_start`) is set to `-infection_seed_method.n_timepoints`.
+        The relative starting time of the time series (`t_start`) is set to `-infection_init_method.n_timepoints`.
 
         Returns
         -------
         None
         """
         InfectionInitializationProcess.validate(
-            I_pre_seed_rv, infection_seed_method
+            I_pre_init_rv, infection_init_method
         )
 
-        self.I_pre_seed_rv = I_pre_seed_rv
-        self.infection_seed_method = infection_seed_method
+        self.I_pre_init_rv = I_pre_init_rv
+        self.infection_init_method = infection_init_method
         self.name = name
         if t_start is None:
-            t_start = -infection_seed_method.n_timepoints
+            t_start = -infection_init_method.n_timepoints
 
         self.set_timeseries(
             t_start=t_start,
@@ -58,33 +58,33 @@ class InfectionInitializationProcess(RandomVariable):
 
     @staticmethod
     def validate(
-        I_pre_seed_rv: RandomVariable,
-        infection_seed_method: InfectionInitializationMethod,
+        I_pre_init_rv: RandomVariable,
+        infection_init_method: InfectionInitializationMethod,
     ) -> None:
         """Validate the input arguments to the InfectionInitializationProcess class constructor
 
         Parameters
         ----------
-        I_pre_seed_rv : RandomVariable
+        I_pre_init_rv : RandomVariable
             A random variable representing the number of infections that occur at some time before the renewal process begins.
-        infection_seed_method : InfectionInitializationMethod
+        infection_init_method : InfectionInitializationMethod
             An method to generate the initial infections.
 
         Returns
         -------
         None
         """
-        if not isinstance(I_pre_seed_rv, RandomVariable):
+        if not isinstance(I_pre_init_rv, RandomVariable):
             raise TypeError(
-                "I_pre_seed_rv must be an instance of RandomVariable"
-                f"Got {type(I_pre_seed_rv)}"
+                "I_pre_init_rv must be an instance of RandomVariable"
+                f"Got {type(I_pre_init_rv)}"
             )
         if not isinstance(
-            infection_seed_method, InfectionInitializationMethod
+            infection_init_method, InfectionInitializationMethod
         ):
             raise TypeError(
-                "infection_seed_method must be an instance of InfectionInitializationMethod"
-                f"Got {type(infection_seed_method)}"
+                "infection_init_method must be an instance of InfectionInitializationMethod"
+                f"Got {type(infection_init_method)}"
             )
 
     def sample(self) -> tuple:
@@ -95,8 +95,8 @@ class InfectionInitializationProcess(RandomVariable):
         tuple
             a tuple where the only element is an array with the number of seeded infections at each time point.
         """
-        (I_pre_seed,) = self.I_pre_seed_rv()
-        infection_seeding = self.infection_seed_method(I_pre_seed)
+        (I_pre_init,) = self.I_pre_init_rv()
+        infection_seeding = self.infection_init_method(I_pre_init)
         npro.deterministic(self.name, infection_seeding)
 
         return (infection_seeding,)

--- a/model/src/test/test_infection_seeding_method.py
+++ b/model/src/test/test_infection_seeding_method.py
@@ -10,118 +10,120 @@ from pyrenew.latent import (
 )
 
 
-def test_seed_infections_exponential():
+def test_initialize_infections_exponential():
     """Check that the InitializeInfectionsExponentialGrowth class generates the correct number of infections at each time point."""
     n_timepoints = 10
     rate_RV = DeterministicVariable(0.5, name="rate_RV")
-    I_pre_seed_RV = DeterministicVariable(10.0, name="I_pre_seed_RV")
-    default_t_pre_seed = n_timepoints - 1
+    I_pre_init_RV = DeterministicVariable(10.0, name="I_pre_init_RV")
+    default_t_pre_init = n_timepoints - 1
 
-    (I_pre_seed,) = I_pre_seed_RV()
+    (I_pre_init,) = I_pre_init_RV()
     (rate,) = rate_RV()
 
-    infections_default_t_pre_seed = InitializeInfectionsExponentialGrowth(
+    infections_default_t_pre_init = InitializeInfectionsExponentialGrowth(
         n_timepoints, rate=rate_RV
-    ).seed_infections(I_pre_seed)
-    infections_default_t_pre_seed_manual = I_pre_seed * np.exp(
-        rate * (np.arange(n_timepoints) - default_t_pre_seed)
+    ).initialize_infections(I_pre_init)
+    infections_default_t_pre_init_manual = I_pre_init * np.exp(
+        rate * (np.arange(n_timepoints) - default_t_pre_init)
     )
 
     testing.assert_array_almost_equal(
-        infections_default_t_pre_seed, infections_default_t_pre_seed_manual
+        infections_default_t_pre_init, infections_default_t_pre_init_manual
     )
 
-    # assert that infections at default t_pre_seed is I_pre_seed
-    assert infections_default_t_pre_seed[default_t_pre_seed] == I_pre_seed
+    # assert that infections at default t_pre_init is I_pre_init
+    assert infections_default_t_pre_init[default_t_pre_init] == I_pre_init
 
-    # test for failure with non-scalar rate or I_pre_seed
+    # test for failure with non-scalar rate or I_pre_init
     rate_RV_2 = DeterministicVariable(np.array([0.5, 0.5]), name="rate_RV")
     with pytest.raises(ValueError):
         InitializeInfectionsExponentialGrowth(
             n_timepoints, rate=rate_RV_2
-        ).seed_infections(I_pre_seed)
+        ).initialize_infections(I_pre_init)
 
-    I_pre_seed_RV_2 = DeterministicVariable(
-        np.array([10.0, 10.0]), name="I_pre_seed_RV"
+    I_pre_init_RV_2 = DeterministicVariable(
+        np.array([10.0, 10.0]), name="I_pre_init_RV"
     )
-    (I_pre_seed_2,) = I_pre_seed_RV_2()
+    (I_pre_init_2,) = I_pre_init_RV_2()
 
     with pytest.raises(ValueError):
         InitializeInfectionsExponentialGrowth(
             n_timepoints, rate=rate_RV
-        ).seed_infections(I_pre_seed_2)
+        ).initialize_infections(I_pre_init_2)
 
-    # test non-default t_pre_seed
-    t_pre_seed = 6
-    infections_custom_t_pre_seed = InitializeInfectionsExponentialGrowth(
-        n_timepoints, rate=rate_RV, t_pre_seed=t_pre_seed
-    ).seed_infections(I_pre_seed)
-    infections_custom_t_pre_seed_manual = I_pre_seed * np.exp(
-        rate * (np.arange(n_timepoints) - t_pre_seed)
+    # test non-default t_pre_init
+    t_pre_init = 6
+    infections_custom_t_pre_init = InitializeInfectionsExponentialGrowth(
+        n_timepoints, rate=rate_RV, t_pre_init=t_pre_init
+    ).initialize_infections(I_pre_init)
+    infections_custom_t_pre_init_manual = I_pre_init * np.exp(
+        rate * (np.arange(n_timepoints) - t_pre_init)
     )
     testing.assert_array_almost_equal(
-        infections_custom_t_pre_seed,
-        infections_custom_t_pre_seed_manual,
+        infections_custom_t_pre_init,
+        infections_custom_t_pre_init_manual,
         decimal=5,
     )
 
-    assert infections_custom_t_pre_seed[t_pre_seed] == I_pre_seed
+    assert infections_custom_t_pre_init[t_pre_init] == I_pre_init
 
 
-def test_seed_infections_zero_pad():
+def test_initialize_infections_zero_pad():
     """Check that the InitializeInfectionsZeroPad class generates the correct number of infections at each time point."""
 
     n_timepoints = 10
-    I_pre_seed_RV = DeterministicVariable(10.0, name="I_pre_seed_RV")
-    (I_pre_seed,) = I_pre_seed_RV()
+    I_pre_init_RV = DeterministicVariable(10.0, name="I_pre_init_RV")
+    (I_pre_init,) = I_pre_init_RV()
 
-    infections = InitializeInfectionsZeroPad(n_timepoints).seed_infections(
-        I_pre_seed
-    )
+    infections = InitializeInfectionsZeroPad(
+        n_timepoints
+    ).initialize_infections(I_pre_init)
     testing.assert_array_equal(
-        infections, np.pad(I_pre_seed, (n_timepoints - I_pre_seed.size, 0))
+        infections, np.pad(I_pre_init, (n_timepoints - I_pre_init.size, 0))
     )
 
-    I_pre_seed_RV_2 = DeterministicVariable(
-        np.array([10.0, 10.0]), name="I_pre_seed_RV"
+    I_pre_init_RV_2 = DeterministicVariable(
+        np.array([10.0, 10.0]), name="I_pre_init_RV"
     )
-    (I_pre_seed_2,) = I_pre_seed_RV_2()
+    (I_pre_init_2,) = I_pre_init_RV_2()
 
-    infections_2 = InitializeInfectionsZeroPad(n_timepoints).seed_infections(
-        I_pre_seed_2
-    )
+    infections_2 = InitializeInfectionsZeroPad(
+        n_timepoints
+    ).initialize_infections(I_pre_init_2)
     testing.assert_array_equal(
         infections_2,
-        np.pad(I_pre_seed_2, (n_timepoints - I_pre_seed_2.size, 0)),
+        np.pad(I_pre_init_2, (n_timepoints - I_pre_init_2.size, 0)),
     )
 
-    # Check that the InitializeInfectionsZeroPad class raises an error when the length of I_pre_seed is greater than n_timepoints.
+    # Check that the InitializeInfectionsZeroPad class raises an error when the length of I_pre_init is greater than n_timepoints.
     with pytest.raises(ValueError):
-        InitializeInfectionsZeroPad(1).seed_infections(I_pre_seed_2)
+        InitializeInfectionsZeroPad(1).initialize_infections(I_pre_init_2)
 
 
-def test_seed_infections_from_vec():
+def test_initialize_infections_from_vec():
     """Check that the InitializeInfectionsFromVec class generates the correct number of infections at each time point."""
     n_timepoints = 10
-    I_pre_seed = np.arange(n_timepoints)
+    I_pre_init = np.arange(n_timepoints)
 
-    infections = InitializeInfectionsFromVec(n_timepoints).seed_infections(
-        I_pre_seed
-    )
-    testing.assert_array_equal(infections, I_pre_seed)
+    infections = InitializeInfectionsFromVec(
+        n_timepoints
+    ).initialize_infections(I_pre_init)
+    testing.assert_array_equal(infections, I_pre_init)
 
-    I_pre_seed_2 = np.arange(n_timepoints - 1)
+    I_pre_init_2 = np.arange(n_timepoints - 1)
     with pytest.raises(ValueError):
-        InitializeInfectionsFromVec(n_timepoints).seed_infections(I_pre_seed_2)
+        InitializeInfectionsFromVec(n_timepoints).initialize_infections(
+            I_pre_init_2
+        )
 
     n_timepoints_float = 10.0
     with pytest.raises(TypeError):
-        InitializeInfectionsFromVec(n_timepoints_float).seed_infections(
-            I_pre_seed
+        InitializeInfectionsFromVec(n_timepoints_float).initialize_infections(
+            I_pre_init
         )
 
     n_timepoints_neg = -10
     with pytest.raises(ValueError):
-        InitializeInfectionsFromVec(n_timepoints_neg).seed_infections(
-            I_pre_seed
+        InitializeInfectionsFromVec(n_timepoints_neg).initialize_infections(
+            I_pre_init
         )


### PR DESCRIPTION
> The author of this issue recently found some `seed` names that had missed being changed (e.g. `I_pre_seed` and `I_pre_seed_rv`). These are now to be changed to `init` with permission from @damonbayer. 