### PR TITLE
Change Naming Of `n_timepoints_to_simulate` 

### DIFF
--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -205,7 +205,7 @@ Using `numpyro`, we can simulate data using the `sample()` member function of `R
 ```{python}
 # | label: simulate
 with numpyro.handlers.seed(rng_seed=53):
-    sim_data = model1.sample(n_timepoints_to_simulate=40)
+    sim_data = model1.sample(n_datapoints=40)
 
 sim_data
 ```

--- a/docs/source/tutorials/extending_pyrenew.qmd
+++ b/docs/source/tutorials/extending_pyrenew.qmd
@@ -91,7 +91,7 @@ And simulate from it:
 # Sampling and fitting model 0 (with no obs for infections)
 np.random.seed(223)
 with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-    model0_samp = model0.sample(n_timepoints_to_simulate=30)
+    model0_samp = model0.sample(n_datapoints=30)
 ```
 
 ```{python}
@@ -260,7 +260,7 @@ model1 = RtInfectionsRenewalModel(
 # Sampling and fitting model 0 (with no obs for infections)
 np.random.seed(223)
 with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-    model1_samp = model1.sample(n_timepoints_to_simulate=30)
+    model1_samp = model1.sample(n_datapoints=30)
 ```
 
 Comparing `model0` with `model1`, these two should match:

--- a/docs/source/tutorials/hospital_admissions_model.qmd
+++ b/docs/source/tutorials/hospital_admissions_model.qmd
@@ -259,7 +259,7 @@ timeframe = 120
 
 
 with numpyro.handlers.seed(rng_seed=223):
-    simulated_data = hosp_model.sample(n_timepoints_to_simulate=timeframe)
+    simulated_data = hosp_model.sample(n_datapoints=timeframe)
 ```
 
 ```{python}
@@ -439,10 +439,10 @@ import arviz as az
 idata = az.from_numpyro(
     hosp_model.mcmc,
     posterior_predictive=hosp_model.posterior_predictive(
-        n_timepoints_to_simulate=len(daily_hosp_admits)
+        n_datapoints=len(daily_hosp_admits)
     ),
     prior=hosp_model.prior_predictive(
-        n_timepoints_to_simulate=len(daily_hosp_admits),
+        n_datapoints=len(daily_hosp_admits),
         numpyro_predictive_args={"num_samples": 1000},
     ),
 )
@@ -470,7 +470,7 @@ plt.show()
 ```
 
 
-By increasing `n_timepoints_to_simulate`, we can perform forecasting using the posterior predictive distribution.
+By increasing `n_datapoints`, we can perform forecasting using the posterior predictive distribution.
 
 ```{python}
 # | label: posterior-predictive-distribution
@@ -478,10 +478,10 @@ n_forecast_points = 28
 idata = az.from_numpyro(
     hosp_model.mcmc,
     posterior_predictive=hosp_model.posterior_predictive(
-        n_timepoints_to_simulate=len(daily_hosp_admits) + n_forecast_points,
+        n_datapoints=len(daily_hosp_admits) + n_forecast_points,
     ),
     prior=hosp_model.prior_predictive(
-        n_timepoints_to_simulate=len(daily_hosp_admits),
+        n_datapoints=len(daily_hosp_admits),
         numpyro_predictive_args={"num_samples": 1000},
     ),
 )

--- a/model/src/pyrenew/model/admissionsmodel.py
+++ b/model/src/pyrenew/model/admissionsmodel.py
@@ -133,7 +133,7 @@ class HospitalAdmissionsModel(Model):
 
     def sample(
         self,
-        n_timepoints_to_simulate: int | None = None,
+        n_datapoints: int | None = None,
         data_observed_hosp_admissions: ArrayLike | None = None,
         padding: int = 0,
         **kwargs,
@@ -143,7 +143,7 @@ class HospitalAdmissionsModel(Model):
 
         Parameters
         ----------
-        n_timepoints_to_simulate : int, optional
+        n_datapoints : int, optional
             Number of timepoints to sample (passed to the basic renewal model).
         data_observed_hosp_admissions : ArrayLike, optional
             The observed hospitalization data (passed to the basic renewal
@@ -164,29 +164,26 @@ class HospitalAdmissionsModel(Model):
         basic_renewal.sample : For sampling the basic renewal model
         sample_observed_admissions : For sampling observed hospital admissions
         """
-        if (
-            n_timepoints_to_simulate is None
-            and data_observed_hosp_admissions is None
-        ):
+        if n_datapoints is None and data_observed_hosp_admissions is None:
             raise ValueError(
-                "Either n_timepoints_to_simulate or data_observed_hosp_admissions "
+                "Either n_datapoints or data_observed_hosp_admissions "
                 "must be passed."
             )
         elif (
-            n_timepoints_to_simulate is not None
+            n_datapoints is not None
             and data_observed_hosp_admissions is not None
         ):
             raise ValueError(
-                "Cannot pass both n_timepoints_to_simulate and data_observed_hosp_admissions."
+                "Cannot pass both n_datapoints and data_observed_hosp_admissions."
             )
-        elif n_timepoints_to_simulate is None:
+        elif n_datapoints is None:
             n_datapoints = len(data_observed_hosp_admissions)
         else:
-            n_datapoints = n_timepoints_to_simulate
+            n_datapoints = n_datapoints
 
         # Getting the initial quantities from the basic model
         basic_model = self.basic_renewal.sample(
-            n_timepoints_to_simulate=n_datapoints,
+            n_datapoints=n_datapoints,
             data_observed_infections=None,
             padding=padding,
             **kwargs,

--- a/model/src/pyrenew/model/rtinfectionsrenewalmodel.py
+++ b/model/src/pyrenew/model/rtinfectionsrenewalmodel.py
@@ -141,7 +141,7 @@ class RtInfectionsRenewalModel(Model):
 
     def sample(
         self,
-        n_timepoints_to_simulate: int | None = None,
+        n_datapoints: int | None = None,
         data_observed_infections: ArrayLike | None = None,
         padding: int = 0,
         **kwargs,
@@ -151,7 +151,7 @@ class RtInfectionsRenewalModel(Model):
 
         Parameters
         ----------
-        n_timepoints_to_simulate : int, optional
+        n_datapoints : int, optional
             Number of timepoints to sample.
         data_observed_infections : ArrayLike | None, optional
             Observed infections. Defaults to None.
@@ -164,7 +164,7 @@ class RtInfectionsRenewalModel(Model):
 
         Notes
         -----
-        Either `data_observed_infections` or `n_timepoints_to_simulate`
+        Either `data_observed_infections` or `n_datapoints`
         must be specified, not both.
 
         Returns
@@ -172,25 +172,19 @@ class RtInfectionsRenewalModel(Model):
         RtInfectionsRenewalSample
         """
 
-        if (
-            n_timepoints_to_simulate is None
-            and data_observed_infections is None
-        ):
+        if n_datapoints is None and data_observed_infections is None:
             raise ValueError(
-                "Either n_timepoints_to_simulate or data_observed_infections "
+                "Either n_datapoints or data_observed_infections "
                 "must be passed."
             )
-        elif (
-            n_timepoints_to_simulate is not None
-            and data_observed_infections is not None
-        ):
+        elif n_datapoints is not None and data_observed_infections is not None:
             raise ValueError(
-                "Cannot pass both n_timepoints_to_simulate and data_observed_infections."
+                "Cannot pass both n_datapoints and data_observed_infections."
             )
-        elif n_timepoints_to_simulate is None:
+        elif n_datapoints is None:
             n_timepoints = len(data_observed_infections) + padding
         else:
-            n_timepoints = n_timepoints_to_simulate + padding
+            n_timepoints = n_datapoints + padding
         # Sampling from Rt (possibly with a given Rt, depending on
         # the Rt_process (RandomVariable) object.)
         Rt, *_ = self.Rt_process_rv(

--- a/model/src/test/test_forecast.py
+++ b/model/src/test/test_forecast.py
@@ -49,12 +49,10 @@ def test_forecast():
         Rt_process_rv=rt,
     )
 
-    n_timepoints_to_simulate = 30
+    n_datapoints = 30
     n_forecast_points = 10
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model_sample = model.sample(
-            n_timepoints_to_simulate=n_timepoints_to_simulate
-        )
+        model_sample = model.sample(n_datapoints=n_datapoints)
 
     model.run(
         num_warmup=5,
@@ -64,13 +62,13 @@ def test_forecast():
     )
 
     posterior_predictive_samples = model.posterior_predictive(
-        n_timepoints_to_simulate=n_timepoints_to_simulate + n_forecast_points,
+        n_datapoints=n_datapoints + n_forecast_points,
     )
 
     # Check the length of the predictive distribution
     assert (
         len(posterior_predictive_samples["poisson_rv"][0])
-        == n_timepoints_to_simulate + n_forecast_points
+        == n_datapoints + n_forecast_points
     )
 
     # Check the first elements of the posterior predictive Rt are the same as the

--- a/model/src/test/test_model_basic_renewal.py
+++ b/model/src/test/test_model_basic_renewal.py
@@ -47,7 +47,7 @@ def get_default_rt():
 def test_model_basicrenewal_no_timepoints_or_observations():
     """
     Test that the basic renewal model does not run
-    without either n_timepoints_to_simulate or
+    without either n_datapoints or
     observed_admissions
     """
 
@@ -74,14 +74,12 @@ def test_model_basicrenewal_no_timepoints_or_observations():
     np.random.seed(2203)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
         with pytest.raises(ValueError, match="Either"):
-            model1.sample(
-                n_timepoints_to_simulate=None, data_observed_infections=None
-            )
+            model1.sample(n_datapoints=None, data_observed_infections=None)
 
 
 def test_model_basicrenewal_both_timepoints_and_observations():
     """
-    Test that the basic renewal model does not run with both n_timepoints_to_simulate and observed_admissions passed
+    Test that the basic renewal model does not run with both n_datapoints and observed_admissions passed
     """
 
     gen_int = DeterministicPMF(
@@ -108,7 +106,7 @@ def test_model_basicrenewal_both_timepoints_and_observations():
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
         with pytest.raises(ValueError, match="Cannot pass both"):
             model1.sample(
-                n_timepoints_to_simulate=30,
+                n_datapoints=30,
                 data_observed_infections=jnp.repeat(jnp.nan, 30),
             )
 
@@ -149,7 +147,7 @@ def test_model_basicrenewal_no_obs_model():
     # Sampling and fitting model 0 (with no obs for infections)
     np.random.seed(223)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model0_samp = model0.sample(n_timepoints_to_simulate=30)
+        model0_samp = model0.sample(n_datapoints=30)
     model0_samp.Rt
     model0_samp.latent_infections
     model0_samp.observed_infections
@@ -158,7 +156,7 @@ def test_model_basicrenewal_no_obs_model():
     model0.infection_obs_process_rv = NullObservation()
     np.random.seed(223)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model1_samp = model0.sample(n_timepoints_to_simulate=30)
+        model1_samp = model0.sample(n_datapoints=30)
 
     np.testing.assert_array_equal(model0_samp.Rt, model1_samp.Rt)
     np.testing.assert_array_equal(
@@ -222,7 +220,7 @@ def test_model_basicrenewal_with_obs_model():
     # Sampling and fitting model 1 (with obs infections)
     np.random.seed(2203)
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model1_samp = model1.sample(n_timepoints_to_simulate=30)
+        model1_samp = model1.sample(n_datapoints=30)
 
     model1.run(
         num_warmup=500,
@@ -273,9 +271,7 @@ def test_model_basicrenewal_padding() -> None:  # numpydoc ignore=GL08
     np.random.seed(2203)
     pad_size = 5
     with npro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model1_samp = model1.sample(
-            n_timepoints_to_simulate=30, padding=pad_size
-        )
+        model1_samp = model1.sample(n_datapoints=30, padding=pad_size)
 
     model1.run(
         num_warmup=500,

--- a/model/src/test/test_model_hosp_admissions.py
+++ b/model/src/test/test_model_hosp_admissions.py
@@ -74,7 +74,7 @@ class UniformProbForTest(RandomVariable):  # numpydoc ignore=GL08
 def test_model_hosp_no_timepoints_or_observations():
     """
     Checks that the hospital admissions model does not run
-    without either n_timepoints_to_simulate or observed_admissions
+    without either n_datapoints or observed_admissions
     """
 
     gen_int = DeterministicPMF(
@@ -132,15 +132,13 @@ def test_model_hosp_no_timepoints_or_observations():
 
     with numpyro.handlers.seed(rng_seed=233):
         with pytest.raises(ValueError, match="Either"):
-            model1.sample(
-                n_timepoints_to_simulate=None, data_observed_admissions=None
-            )
+            model1.sample(n_datapoints=None, data_observed_admissions=None)
 
 
 def test_model_hosp_both_timepoints_and_observations():
     """
     Checks that the hospital admissions model does not run with
-    both n_timepoints_to_simulate and observed_admissions passed
+    both n_datapoints and observed_admissions passed
     """
 
     gen_int = DeterministicPMF(
@@ -200,7 +198,7 @@ def test_model_hosp_both_timepoints_and_observations():
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
         with pytest.raises(ValueError, match="Cannot pass both"):
             model1.sample(
-                n_timepoints_to_simulate=30,
+                n_datapoints=30,
                 data_observed_hosp_admissions=jnp.repeat(jnp.nan, 30),
             )
 
@@ -271,13 +269,13 @@ def test_model_hosp_no_obs_model():
     # Sampling and fitting model 0 (with no obs for infections)
     np.random.seed(223)
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model0_samp = model0.sample(n_timepoints_to_simulate=30)
+        model0_samp = model0.sample(n_datapoints=30)
 
     model0.hosp_admission_obs_process_rv = NullObservation()
 
     np.random.seed(223)
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model1_samp = model0.sample(n_timepoints_to_simulate=30)
+        model1_samp = model0.sample(n_datapoints=30)
 
     np.testing.assert_array_almost_equal(model0_samp.Rt, model1_samp.Rt)
     np.testing.assert_array_equal(
@@ -378,7 +376,7 @@ def test_model_hosp_with_obs_model():
     # Sampling and fitting model 0 (with no obs for infections)
     np.random.seed(223)
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model1_samp = model1.sample(n_timepoints_to_simulate=30)
+        model1_samp = model1.sample(n_datapoints=30)
 
     model1.run(
         num_warmup=500,
@@ -475,7 +473,7 @@ def test_model_hosp_with_obs_model_weekday_phosp_2():
     # Sampling and fitting model 0 (with no obs for infections)
     np.random.seed(223)
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model1_samp = model1.sample(n_timepoints_to_simulate=30)
+        model1_samp = model1.sample(n_datapoints=30)
 
     model1.run(
         num_warmup=500,
@@ -586,7 +584,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
     np.random.seed(223)
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
         model1_samp = model1.sample(
-            n_timepoints_to_simulate=n_obs_to_generate, padding=pad_size
+            n_datapoints=n_obs_to_generate, padding=pad_size
         )
 
     # Running with padding

--- a/model/src/test/test_predictive.py
+++ b/model/src/test/test_predictive.py
@@ -54,4 +54,4 @@ def test_posterior_predictive_no_posterior():
     no posterior samples are available.
     """
     with pytest.raises(ValueError, match="No posterior"):
-        model.posterior_predictive(n_timepoints_to_simulate=10)
+        model.posterior_predictive(n_datapoints=10)

--- a/model/src/test/test_random_key.py
+++ b/model/src/test/test_random_key.py
@@ -67,21 +67,21 @@ def run_test_model(
 
 
 def prior_predictive_test_model(
-    test_model, n_timepoints_to_simulate, rng_key
+    test_model, n_datapoints, rng_key
 ):  # numpydoc ignore=GL08
     prior_predictive_samples = test_model.prior_predictive(
         rng_key=rng_key,
         numpyro_predictive_args={"num_samples": 20},
-        n_timepoints_to_simulate=n_timepoints_to_simulate,
+        n_datapoints=n_datapoints,
     )
     return prior_predictive_samples
 
 
 def posterior_predictive_test_model(
-    test_model, n_timepoints_to_simulate, rng_key
+    test_model, n_datapoints, rng_key
 ):  # numpydoc ignore=GL08
     posterior_predictive_samples = test_model.posterior_predictive(
-        rng_key=rng_key, n_timepoints_to_simulate=n_timepoints_to_simulate
+        rng_key=rng_key, n_datapoints=n_datapoints
     )
     return posterior_predictive_samples
 
@@ -97,16 +97,14 @@ def test_rng_keys_produce_correct_samples():
 
     # set up base models for testing
     models = [create_test_model() for _ in range(5)]
-    n_timepoints_to_simulate = [30] * len(models)
+    n_datapoints = [30] * len(models)
     n_timepoints_posterior_predictive = [
-        x + models[0].gen_int_rv.size() for x in n_timepoints_to_simulate
+        x + models[0].gen_int_rv.size() for x in n_datapoints
     ]
     # sample only a single model and use that model's samples
     # as the observed_infections for the rest of the models
     with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
-        model_sample = models[0].sample(
-            n_timepoints_to_simulate=n_timepoints_to_simulate[0]
-        )
+        model_sample = models[0].sample(n_datapoints=n_datapoints[0])
     obs_infections = [model_sample.observed_infections] * len(models)
     rng_keys = [jr.key(54), jr.key(54), None, None, jr.key(74)]
 
@@ -117,7 +115,7 @@ def test_rng_keys_produce_correct_samples():
 
     prior_predictive_list = [
         prior_predictive_test_model(*elt)
-        for elt in list(zip(models, n_timepoints_to_simulate, rng_keys))
+        for elt in list(zip(models, n_datapoints, rng_keys))
     ]
 
     posterior_predictive_list = [


### PR DESCRIPTION
As per #249 , `n_timepoints_to_simulate` can be shortened; this PR shortens `n_timepoints_to_simulate` to `n_datapoints`. 