### PR TITLE
Maintain Consistent `rng_key` Valuing

### DIFF
--- a/model/src/test/test_model_hosp_admissions.py
+++ b/model/src/test/test_model_hosp_admissions.py
@@ -130,7 +130,7 @@ def test_model_hosp_no_timepoints_or_observations():
         hosp_admission_obs_process_rv=observed_admissions,
     )
 
-    with numpyro.handlers.seed(rng_seed=233):
+    with numpyro.handlers.seed(rng_seed=223):
         with pytest.raises(ValueError, match="Either"):
             model1.sample(n_datapoints=None, data_observed_admissions=None)
 
@@ -194,8 +194,7 @@ def test_model_hosp_both_timepoints_and_observations():
         hosp_admission_obs_process_rv=observed_admissions,
     )
 
-    np.random.seed(223)
-    with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
+    with numpyro.handlers.seed(rng_seed=223):
         with pytest.raises(ValueError, match="Cannot pass both"):
             model1.sample(
                 n_datapoints=30,
@@ -266,14 +265,12 @@ def test_model_hosp_no_obs_model():
     )
 
     # Sampling and fitting model 0 (with no obs for infections)
-    np.random.seed(223)
-    with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
+    with numpyro.handlers.seed(rng_seed=223):
         model0_samp = model0.sample(n_datapoints=30)
 
     model0.hosp_admission_obs_process_rv = NullObservation()
 
-    np.random.seed(223)
-    with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
+    with numpyro.handlers.seed(rng_seed=223):
         model1_samp = model0.sample(n_datapoints=30)
 
     np.testing.assert_array_almost_equal(model0_samp.Rt, model1_samp.Rt)
@@ -373,8 +370,7 @@ def test_model_hosp_with_obs_model():
     )
 
     # Sampling and fitting model 0 (with no obs for infections)
-    np.random.seed(223)
-    with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
+    with numpyro.handlers.seed(rng_seed=233):
         model1_samp = model1.sample(n_datapoints=30)
 
     model1.run(
@@ -470,8 +466,7 @@ def test_model_hosp_with_obs_model_weekday_phosp_2():
     )
 
     # Sampling and fitting model 0 (with no obs for infections)
-    np.random.seed(223)
-    with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
+    with numpyro.handlers.seed(rng_seed=223):
         model1_samp = model1.sample(n_datapoints=30)
 
     model1.run(
@@ -579,9 +574,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
     )
 
     # Sampling and fitting model 0 (with no obs for infections)
-
-    np.random.seed(223)
-    with numpyro.handlers.seed(rng_seed=np.random.randint(1, 600)):
+    with numpyro.handlers.seed(rng_seed=223):
         model1_samp = model1.sample(
             n_datapoints=n_obs_to_generate, padding=pad_size
         )


### PR DESCRIPTION
This PR takes instances matching this pattern:

```python
np.random.seed(223)
with numpyro.handlers.seed(rng_seed=np.random.randint(1, 60)):
    model.sample()
```

and updates them to this pattern:

```python
with numpyro.handlers.seed(rng_seed=223):
    model.sample()
```

Oftentimes, in the same file or tutorial, the same `rng_seed` value will be used (e.g., 223 in the above example) across instances of `numpyro.handlers.seed()`. This PR maintains this consistency at the file level, so if all `np.random.seed()`s had value 62 in a file, then all `rng_seed` values in that file are also valued at 62. 