### PR TITLE
Rename Deterministic `vars` Attribute To `value`

### DIFF
--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -121,7 +121,7 @@ To initialize these five components within the renewal modeling framework, we es
 # | label: creating-elements
 # (1) The generation interval (deterministic)
 pmf_array = jnp.array([0.4, 0.3, 0.2, 0.1])
-gen_int = DeterministicPMF(name="gen_int", vars=pmf_array)
+gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
 
 # (2) Initial infections (inferred with a prior)
 I0 = InfectionInitializationProcess(

--- a/docs/source/tutorials/extending_pyrenew.qmd
+++ b/docs/source/tutorials/extending_pyrenew.qmd
@@ -42,15 +42,15 @@ The following code-chunk defines the model components. Notice that for both the 
 ```{python}
 # | label: model-components
 gen_int_array = jnp.array([0.25, 0.5, 0.15, 0.1])
-gen_int = DeterministicPMF(name="gen_int", vars=gen_int_array)
-feedback_strength = DeterministicVariable(name="feedback_strength", vars=0.05)
+gen_int = DeterministicPMF(name="gen_int", value=gen_int_array)
+feedback_strength = DeterministicVariable(name="feedback_strength", value=0.05)
 
 I0 = InfectionInitializationProcess(
     "I0_initialization",
     DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
     InitializeInfectionsExponentialGrowth(
         gen_int_array.size,
-        DeterministicVariable(name="rate", vars=0.5),
+        DeterministicVariable(name="rate", value=0.5),
     ),
     t_unit=1,
 )

--- a/docs/source/tutorials/hospital_admissions_model.qmd
+++ b/docs/source/tutorials/hospital_admissions_model.qmd
@@ -142,7 +142,7 @@ import jax.numpy as jnp
 import numpyro.distributions as dist
 
 inf_hosp_int = deterministic.DeterministicPMF(
-    name="inf_hosp_int", vars=inf_hosp_int
+    name="inf_hosp_int", value=inf_hosp_int
 )
 
 hosp_rate = metaclass.DistributionalRV(
@@ -175,13 +175,13 @@ I0 = InfectionInitializationProcess(
     ),
     InitializeInfectionsExponentialGrowth(
         gen_int_array.size,
-        deterministic.DeterministicVariable(name="rate", vars=0.05),
+        deterministic.DeterministicVariable(name="rate", value=0.05),
     ),
     t_unit=1,
 )
 
 # Generation interval and Rt
-gen_int = deterministic.DeterministicPMF(name="gen_int", vars=gen_int)
+gen_int = deterministic.DeterministicPMF(name="gen_int", value=gen_int)
 
 
 class MyRt(metaclass.RandomVariable):

--- a/docs/source/tutorials/periodic_effects.qmd
+++ b/docs/source/tutorials/periodic_effects.qmd
@@ -28,13 +28,13 @@ rt_proc = process.RtWeeklyDiffProcess(
     name="rt_weekly_diff",
     offset=0,
     log_rt_prior=deterministic.DeterministicVariable(
-        name="log_rt_prior", vars=jnp.array([0.1, 0.2])
+        name="log_rt_prior", value=jnp.array([0.1, 0.2])
     ),
     autoreg=deterministic.DeterministicVariable(
-        name="autoreg", vars=jnp.array([0.7])
+        name="autoreg", value=jnp.array([0.7])
     ),
     periodic_diff_sd=deterministic.DeterministicVariable(
-        name="periodic_diff_sd", vars=jnp.array([0.1])
+        name="periodic_diff_sd", value=jnp.array([0.1])
     ),
 )
 ```

--- a/model/src/pyrenew/deterministic/deterministic.py
+++ b/model/src/pyrenew/deterministic/deterministic.py
@@ -18,7 +18,7 @@ class DeterministicVariable(RandomVariable):
     def __init__(
         self,
         name: str,
-        vars: ArrayLike,
+        value: ArrayLike,
     ) -> None:
         """Default constructor
 
@@ -26,7 +26,7 @@ class DeterministicVariable(RandomVariable):
         ----------
         name : str
             A name to assign to the process.
-        vars : ArrayLike
+        value : ArrayLike
             An ArrayLike object.
 
         Returns
@@ -35,19 +35,19 @@ class DeterministicVariable(RandomVariable):
         """
 
         self.name = name
-        self.vars = jnp.atleast_1d(vars)
-        self.validate(vars)
+        self.value = jnp.atleast_1d(value)
+        self.validate(value)
 
         return None
 
     @staticmethod
-    def validate(vars: ArrayLike) -> None:
+    def validate(value: ArrayLike) -> None:
         """
         Validates input to DeterministicPMF
 
         Parameters
         ----------
-        vars : ArrayLike
+        value : ArrayLike
             An ArrayLike object.
 
         Returns
@@ -57,10 +57,10 @@ class DeterministicVariable(RandomVariable):
         Raises
         ------
         Exception
-            If the input vars object is not a ArrayLike.
+            If the input value object is not a ArrayLike.
         """
-        if not isinstance(vars, ArrayLike):
-            raise Exception("vars is not a ArrayLike")
+        if not isinstance(value, ArrayLike):
+            raise Exception("value is not a ArrayLike")
 
         return None
 
@@ -86,5 +86,5 @@ class DeterministicVariable(RandomVariable):
             Containing the stored values during construction.
         """
         if record:
-            numpyro.deterministic(self.name, self.vars)
-        return (self.vars,)
+            numpyro.deterministic(self.name, self.value)
+        return (self.value,)

--- a/model/src/pyrenew/deterministic/deterministicpmf.py
+++ b/model/src/pyrenew/deterministic/deterministicpmf.py
@@ -16,13 +16,13 @@ class DeterministicPMF(RandomVariable):
     def __init__(
         self,
         name: str,
-        vars: ArrayLike,
+        value: ArrayLike,
         tol: float = 1e-5,
     ) -> None:
         """
         Default constructor
 
-        Automatically checks that the elements in `vars` can be indeed
+        Automatically checks that the elements in `value` can be indeed
         considered to be a PMF by calling
         pyrenew.distutil.validate_discrete_dist_vector on each one of its
         entries.
@@ -31,7 +31,7 @@ class DeterministicPMF(RandomVariable):
         ----------
         name : str
             A name to assign to the variable.
-        vars : tuple
+        value : tuple
             An ArrayLike object.
         tol : float, optional
             Passed to pyrenew.distutil.validate_discrete_dist_vector. Defaults
@@ -41,23 +41,23 @@ class DeterministicPMF(RandomVariable):
         -------
         None
         """
-        vars = validate_discrete_dist_vector(
-            discrete_dist=vars,
+        value = validate_discrete_dist_vector(
+            discrete_dist=value,
             tol=tol,
         )
 
-        self.basevar = DeterministicVariable(name=name, vars=vars)
+        self.basevar = DeterministicVariable(name=name, value=value)
 
         return None
 
     @staticmethod
-    def validate(vars: ArrayLike) -> None:
+    def validate(value: ArrayLike) -> None:
         """
         Validates input to DeterministicPMF
 
         Parameters
         ----------
-        vars : ArrayLike
+        value : ArrayLike
             An ArrayLike object.
 
         Returns
@@ -97,4 +97,4 @@ class DeterministicPMF(RandomVariable):
             The size of the PMF
         """
 
-        return self.basevar.vars.size
+        return self.basevar.value.size

--- a/model/src/pyrenew/latent/hospitaladmissions.py
+++ b/model/src/pyrenew/latent/hospitaladmissions.py
@@ -91,11 +91,11 @@ class HospitalAdmissions(RandomVariable):
 
         if day_of_week_effect_rv is None:
             day_of_week_effect_rv = DeterministicVariable(
-                name="weekday_effect", vars=1
+                name="weekday_effect", value=1
             )
         if hosp_report_prob_rv is None:
             hosp_report_prob_rv = DeterministicVariable(
-                name="hosp_report_prob", vars=1
+                name="hosp_report_prob", value=1
             )
 
         HospitalAdmissions.validate(

--- a/model/src/test/test_deterministic.py
+++ b/model/src/test/test_deterministic.py
@@ -19,16 +19,16 @@ def test_deterministic():
 
     var1 = DeterministicVariable(
         name="var1",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 1,
             ]
         ),
     )
     var2 = DeterministicPMF(
-        name="var2", vars=jnp.array([0.25, 0.25, 0.2, 0.3])
+        name="var2", value=jnp.array([0.25, 0.25, 0.2, 0.3])
     )
-    var3 = DeterministicProcess(name="var3", vars=jnp.array([1, 2, 3, 4]))
+    var3 = DeterministicProcess(name="var3", value=jnp.array([1, 2, 3, 4]))
     var4 = NullVariable()
     var5 = NullProcess()
 

--- a/model/src/test/test_forecast.py
+++ b/model/src/test/test_forecast.py
@@ -21,7 +21,7 @@ from pyrenew.process import SimpleRandomWalkProcess
 def test_forecast():
     """Check that forecasts are the right length and match the posterior up until forecast begins."""
     pmf_array = jnp.array([0.25, 0.25, 0.25, 0.25])
-    gen_int = DeterministicPMF(name="gen_int", vars=pmf_array)
+    gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
     I0 = InfectionInitializationProcess(
         "I0_initialization",
         DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),

--- a/model/src/test/test_infection_seeding_method.py
+++ b/model/src/test/test_infection_seeding_method.py
@@ -13,8 +13,8 @@ from pyrenew.latent import (
 def test_initialize_infections_exponential():
     """Check that the InitializeInfectionsExponentialGrowth class generates the correct number of infections at each time point."""
     n_timepoints = 10
-    rate_RV = DeterministicVariable(name="rate_RV", vars=0.5)
-    I_pre_init_RV = DeterministicVariable(name="I_pre_init_RV", vars=10.0)
+    rate_RV = DeterministicVariable(name="rate_RV", value=0.5)
+    I_pre_init_RV = DeterministicVariable(name="I_pre_init_RV", value=10.0)
     default_t_pre_init = n_timepoints - 1
 
     (I_pre_init,) = I_pre_init_RV()
@@ -36,7 +36,7 @@ def test_initialize_infections_exponential():
 
     # test for failure with non-scalar rate or I_pre_init
     rate_RV_2 = DeterministicVariable(
-        name="rate_RV", vars=np.array([0.5, 0.5])
+        name="rate_RV", value=np.array([0.5, 0.5])
     )
     with pytest.raises(ValueError):
         InitializeInfectionsExponentialGrowth(
@@ -45,7 +45,7 @@ def test_initialize_infections_exponential():
 
     I_pre_init_RV_2 = DeterministicVariable(
         name="I_pre_init_RV",
-        vars=np.array([10.0, 10.0]),
+        value=np.array([10.0, 10.0]),
     )
     (I_pre_init_2,) = I_pre_init_RV_2()
 
@@ -75,7 +75,7 @@ def test_initialize_infections_zero_pad():
     """Check that the InitializeInfectionsZeroPad class generates the correct number of infections at each time point."""
 
     n_timepoints = 10
-    I_pre_init_RV = DeterministicVariable(name="I_pre_init_RV", vars=10.0)
+    I_pre_init_RV = DeterministicVariable(name="I_pre_init_RV", value=10.0)
     (I_pre_init,) = I_pre_init_RV()
 
     infections = InitializeInfectionsZeroPad(
@@ -86,7 +86,7 @@ def test_initialize_infections_zero_pad():
     )
 
     I_pre_init_RV_2 = DeterministicVariable(
-        name="I_pre_init_RV", vars=np.array([10.0, 10.0])
+        name="I_pre_init_RV", value=np.array([10.0, 10.0])
     )
     (I_pre_init_2,) = I_pre_init_RV_2()
 

--- a/model/src/test/test_infection_seeding_process.py
+++ b/model/src/test/test_infection_seeding_process.py
@@ -28,14 +28,14 @@ def test_infection_initialization_process():
         "exp_model",
         DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
         InitializeInfectionsExponentialGrowth(
-            n_timepoints, DeterministicVariable(name="rate", vars=0.5)
+            n_timepoints, DeterministicVariable(name="rate", value=0.5)
         ),
         t_unit=1,
     )
 
     vec_model = InfectionInitializationProcess(
         "vec_model",
-        DeterministicVariable(name="I0", vars=jnp.arange(n_timepoints)),
+        DeterministicVariable(name="I0", value=jnp.arange(n_timepoints)),
         InitializeInfectionsFromVec(n_timepoints),
         t_unit=1,
     )
@@ -56,7 +56,7 @@ def test_infection_initialization_process():
     with pytest.raises(TypeError):
         InfectionInitializationProcess(
             "vec_model",
-            DeterministicVariable(name="I0", vars=jnp.arange(n_timepoints)),
+            DeterministicVariable(name="I0", value=jnp.arange(n_timepoints)),
             3,
             t_unit=1,
         )

--- a/model/src/test/test_infectionsrtfeedback.py
+++ b/model/src/test/test_infectionsrtfeedback.py
@@ -69,9 +69,9 @@ def test_infectionsrtfeedback():
     # By doing the infection feedback strength 0, Rt = Rt_adjusted
     # So infection should be equal in both
     inf_feed_strength = DeterministicVariable(
-        name="inf_feed_strength", vars=jnp.zeros_like(Rt)
+        name="inf_feed_strength", value=jnp.zeros_like(Rt)
     )
-    inf_feedback_pmf = DeterministicPMF(name="inf_feedback_pmf", vars=gen_int)
+    inf_feedback_pmf = DeterministicPMF(name="inf_feedback_pmf", value=gen_int)
 
     # Test the InfectionsWithFeedback class
     InfectionsWithFeedback = latent.InfectionsWithFeedback(
@@ -113,9 +113,9 @@ def test_infectionsrtfeedback_feedback():
     gen_int = jnp.array([0.4, 0.25, 0.25, 0.1, 0.0, 0.0, 0.0])
 
     inf_feed_strength = DeterministicVariable(
-        name="inf_feed_strength", vars=jnp.repeat(0.5, len(Rt))
+        name="inf_feed_strength", value=jnp.repeat(0.5, len(Rt))
     )
-    inf_feedback_pmf = DeterministicPMF(name="inf_feedback_pmf", vars=gen_int)
+    inf_feedback_pmf = DeterministicPMF(name="inf_feedback_pmf", value=gen_int)
 
     # Test the InfectionsWithFeedback class
     InfectionsWithFeedback = latent.InfectionsWithFeedback(

--- a/model/src/test/test_latent_admissions.py
+++ b/model/src/test/test_latent_admissions.py
@@ -48,7 +48,7 @@ def test_admissions_sample():
     # Testing the hospital admissions
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,

--- a/model/src/test/test_model_basic_renewal.py
+++ b/model/src/test/test_model_basic_renewal.py
@@ -56,7 +56,7 @@ def test_model_basicrenewal_no_timepoints_or_observations():
     """
 
     gen_int = DeterministicPMF(
-        name="gen_int", vars=jnp.array([0.25, 0.25, 0.25, 0.25])
+        name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
     I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
@@ -87,7 +87,7 @@ def test_model_basicrenewal_both_timepoints_and_observations():
 
     gen_int = DeterministicPMF(
         name="gen_int",
-        vars=jnp.array([0.25, 0.25, 0.25, 0.25]),
+        value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
     I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
@@ -122,7 +122,7 @@ def test_model_basicrenewal_no_obs_model():
 
     gen_int = DeterministicPMF(
         name="gen_int",
-        vars=jnp.array([0.25, 0.25, 0.25, 0.25]),
+        value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
     with pytest.raises(ValueError):
@@ -195,7 +195,7 @@ def test_model_basicrenewal_with_obs_model():
     """
 
     gen_int = DeterministicPMF(
-        name="gen_int", vars=jnp.array([0.25, 0.25, 0.25, 0.25])
+        name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
     I0 = InfectionInitializationProcess(
@@ -244,7 +244,7 @@ def test_model_basicrenewal_with_obs_model():
 
 def test_model_basicrenewal_padding() -> None:  # numpydoc ignore=GL08
     gen_int = DeterministicPMF(
-        name="gen_int", vars=jnp.array([0.25, 0.25, 0.25, 0.25])
+        name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
     I0 = InfectionInitializationProcess(

--- a/model/src/test/test_model_hosp_admissions.py
+++ b/model/src/test/test_model_hosp_admissions.py
@@ -82,7 +82,7 @@ def test_model_hosp_no_timepoints_or_observations():
     """
 
     gen_int = DeterministicPMF(
-        name="gen_int", vars=jnp.array([0.25, 0.25, 0.25, 0.25])
+        name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
     I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
@@ -94,7 +94,7 @@ def test_model_hosp_no_timepoints_or_observations():
 
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,
@@ -147,7 +147,7 @@ def test_model_hosp_both_timepoints_and_observations():
 
     gen_int = DeterministicPMF(
         name="gen_int",
-        vars=jnp.array([0.25, 0.25, 0.25, 0.25]),
+        value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
     I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
@@ -159,7 +159,7 @@ def test_model_hosp_both_timepoints_and_observations():
 
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,
@@ -215,7 +215,7 @@ def test_model_hosp_no_obs_model():
 
     gen_int = DeterministicPMF(
         name="gen_int",
-        vars=jnp.array([0.25, 0.25, 0.25, 0.25]),
+        value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
     I0 = InfectionInitializationProcess(
@@ -230,7 +230,7 @@ def test_model_hosp_no_obs_model():
 
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,
@@ -320,7 +320,7 @@ def test_model_hosp_with_obs_model():
     """
 
     gen_int = DeterministicPMF(
-        name="gen_int", vars=jnp.array([0.25, 0.25, 0.25, 0.25])
+        name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
     I0 = InfectionInitializationProcess(
@@ -336,7 +336,7 @@ def test_model_hosp_with_obs_model():
 
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,
@@ -407,7 +407,7 @@ def test_model_hosp_with_obs_model_weekday_phosp_2():
 
     gen_int = DeterministicPMF(
         name="gen_int",
-        vars=jnp.array([0.25, 0.25, 0.25, 0.25]),
+        value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
     I0 = InfectionInitializationProcess(
@@ -423,7 +423,7 @@ def test_model_hosp_with_obs_model_weekday_phosp_2():
 
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,
@@ -504,7 +504,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
 
     gen_int = DeterministicPMF(
         name="gen_int",
-        vars=jnp.array([0.25, 0.25, 0.25, 0.25]),
+        value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
     n_obs_to_generate = 30
     pad_size = 5
@@ -523,7 +523,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
 
     inf_hosp = DeterministicPMF(
         name="inf_hosp",
-        vars=jnp.array(
+        value=jnp.array(
             [
                 0,
                 0,
@@ -554,7 +554,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
     weekday = jnp.tile(weekday, 10)
     weekday = weekday[:total_length]
 
-    weekday = DeterministicVariable(name="weekday", vars=weekday)
+    weekday = DeterministicVariable(name="weekday", value=weekday)
 
     hosp_report_prob_dist = jnp.array([0.9, 0.8, 0.7, 0.7, 0.6, 0.4])
     hosp_report_prob_dist = jnp.tile(hosp_report_prob_dist, 10)
@@ -563,7 +563,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
 
     hosp_report_prob_dist = DeterministicVariable(
         name="hosp_report_prob_dist",
-        vars=hosp_report_prob_dist,
+        value=hosp_report_prob_dist,
     )
 
     latent_admissions = HospitalAdmissions(

--- a/model/src/test/test_observation_negativebinom.py
+++ b/model/src/test/test_observation_negativebinom.py
@@ -16,7 +16,7 @@ def test_negativebinom_deterministic_obs():
 
     negb = NegativeBinomialObservation(
         "negbinom_rv",
-        concentration_rv=DeterministicVariable(name="concentration", vars=10),
+        concentration_rv=DeterministicVariable(name="concentration", value=10),
     )
 
     rates = np.random.randint(1, 5, size=10)
@@ -42,7 +42,7 @@ def test_negativebinom_random_obs():
 
     negb = NegativeBinomialObservation(
         "negbinom_rv",
-        concentration_rv=DeterministicVariable(name="concentration", vars=10),
+        concentration_rv=DeterministicVariable(name="concentration", value=10),
     )
 
     rates = np.repeat(5, 20000)

--- a/model/src/test/test_periodiceffect.py
+++ b/model/src/test/test_periodiceffect.py
@@ -13,7 +13,7 @@ def test_periodiceffect() -> None:
     """Checks basic functionality of the process"""
 
     x = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
-    rv = DeterministicVariable(name="weekly-sample", vars=x)
+    rv = DeterministicVariable(name="weekly-sample", value=x)
 
     params = {
         "offset": 0,
@@ -58,7 +58,7 @@ def test_weeklyeffect() -> None:
     """Checks basic functionality of the process"""
 
     x = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
-    rv = DeterministicVariable(name="weekly-sample", vars=x)
+    rv = DeterministicVariable(name="weekly-sample", value=x)
 
     params = {
         "offset": 2,

--- a/model/src/test/test_predictive.py
+++ b/model/src/test/test_predictive.py
@@ -20,7 +20,7 @@ from pyrenew.observation import PoissonObservation
 from pyrenew.process import SimpleRandomWalkProcess
 
 pmf_array = jnp.array([0.25, 0.1, 0.2, 0.45])
-gen_int = DeterministicPMF(name="gen_int", vars=pmf_array)
+gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
 I0 = InfectionInitializationProcess(
     "I0_initialization",
     DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),

--- a/model/src/test/test_random_key.py
+++ b/model/src/test/test_random_key.py
@@ -25,7 +25,7 @@ from pyrenew.process import SimpleRandomWalkProcess
 
 def create_test_model():  # numpydoc ignore=GL08
     pmf_array = jnp.array([0.25, 0.25, 0.25, 0.25])
-    gen_int = DeterministicPMF(name="gen_int", vars=pmf_array)
+    gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
     I0 = InfectionInitializationProcess(
         "I0_initialization",
         DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),

--- a/model/src/test/test_random_walk.py
+++ b/model/src/test/test_random_walk.py
@@ -18,7 +18,7 @@ def test_rw_can_be_sampled():
         name="init_rv_rand",
         dist=dist.Normal(1, 0.5),
     )
-    init_rv_fixed = DeterministicVariable(name="init_rv_fixed", vars=50.0)
+    init_rv_fixed = DeterministicVariable(name="init_rv_fixed", value=50.0)
 
     step_rv = DistributionalRV(
         name="rw_step",
@@ -44,8 +44,8 @@ def test_rw_can_be_sampled():
     assert ans_fixed[0].shape == (5023,)
 
     # check that fixing inits works
-    assert_almost_equal(ans_fixed[0][0], init_rv_fixed.vars)
-    assert ans_rand[0][0] != init_rv_fixed.vars
+    assert_almost_equal(ans_fixed[0][0], init_rv_fixed.value)
+    assert ans_rand[0][0] != init_rv_fixed.value
 
 
 def test_rw_samples_correctly_distributed():
@@ -66,7 +66,7 @@ def test_rw_samples_correctly_distributed():
                 dist=dist.Normal(loc=step_mean, scale=step_sd),
             ),
             init_rv=DeterministicVariable(
-                name="init_rv_fixed", vars=rw_init_val
+                name="init_rv_fixed", value=rw_init_val
             ),
         )
 

--- a/model/src/test/test_rtperiodicdiff.py
+++ b/model/src/test/test_rtperiodicdiff.py
@@ -53,13 +53,13 @@ def test_rtweeklydiff() -> None:
         "name": "test",
         "offset": 0,
         "log_rt_prior": DeterministicVariable(
-            name="log_rt_prior", vars=jnp.array([0.1, 0.2])
+            name="log_rt_prior", value=jnp.array([0.1, 0.2])
         ),
         "autoreg": DeterministicVariable(
-            name="autoreg", vars=jnp.array([0.7])
+            name="autoreg", value=jnp.array([0.7])
         ),
         "periodic_diff_sd": DeterministicVariable(
-            name="periodic_diff_sd", vars=jnp.array([0.1])
+            name="periodic_diff_sd", value=jnp.array([0.1])
         ),
     }
     duration = 30
@@ -100,15 +100,15 @@ def test_rtweeklydiff_no_autoregressive() -> None:
         "name": "test",
         "offset": 0,
         "log_rt_prior": DeterministicVariable(
-            name="log_rt_prior", vars=jnp.array([0.0, 0.0])
+            name="log_rt_prior", value=jnp.array([0.0, 0.0])
         ),
         # No autoregression!
         "autoreg": DeterministicVariable(
-            name="autoreg", vars=jnp.array([0.0])
+            name="autoreg", value=jnp.array([0.0])
         ),
         "periodic_diff_sd": DeterministicVariable(
             name="periodic_diff_sd",
-            vars=jnp.array([0.1]),
+            value=jnp.array([0.1]),
         ),
     }
 
@@ -141,14 +141,14 @@ def test_rtweeklydiff_manual_reconstruction() -> None:
         "offset": 0,
         "log_rt_prior": DeterministicVariable(
             name="log_rt_prior",
-            vars=jnp.array([0.1, 0.2]),
+            value=jnp.array([0.1, 0.2]),
         ),
         "autoreg": DeterministicVariable(
-            name="autoreg", vars=jnp.array([0.7])
+            name="autoreg", value=jnp.array([0.7])
         ),
         "periodic_diff_sd": DeterministicVariable(
             name="periodic_diff_sd",
-            vars=jnp.array([0.1]),
+            value=jnp.array([0.1]),
         ),
     }
 
@@ -180,14 +180,14 @@ def test_rtperiodicdiff_smallsample():
         "offset": 0,
         "log_rt_prior": DeterministicVariable(
             name="log_rt_prior",
-            vars=jnp.array([0.1, 0.2]),
+            value=jnp.array([0.1, 0.2]),
         ),
         "autoreg": DeterministicVariable(
-            name="autoreg", vars=jnp.array([0.7])
+            name="autoreg", value=jnp.array([0.7])
         ),
         "periodic_diff_sd": DeterministicVariable(
             name="periodic_diff_sd",
-            vars=jnp.array([0.1]),
+            value=jnp.array([0.1]),
         ),
     }
 


### PR DESCRIPTION
As per DHM:

> This will make it more consistent with `SampledValue`, and indeed allow for creating new `DeterministicVariable` instances by unpacking `SampledValue` instances (see https://github.com/CDCgov/multisignal-epi-inference/pull/262#discussion_r1690441825)