### PR TITLE
Add `matplotlib` as a core dependency in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ jax = ">=0.4.30"
 jaxlib = ">=0.4.30"
 numpy = "^1.26.4"
 polars = "^1.2.1"
+matplotlib = "^3.8.3"
 
 [tool.poetry.group.dev]
 optional = true
 
 [tool.poetry.group.dev.dependencies]
 pyyaml = "^6.0.0"
-matplotlib = "^3.8.3"
 ipykernel = "^6.29.3"
 nbclient = "^0.10.0"
 nbformat = "^5.10.0"


### PR DESCRIPTION
it is imported from in the `metaclass` module.

Related: this is a reason to separate `docs`, `test` etc dependencies. Tests in CI didn't catch this because it is run in the dev context, and so matplotlib _is_ installed, but as a `dev` dependency rather than as a core dependency.

We also should probably add some explicit checkers for declared but unimported and imported but not declared modules. 

This one looks fairly popular and is under active development
https://github.com/fpgmaas/deptry