### PR TITLE
add test for assert sample and rtype

### DIFF
--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -2,10 +2,13 @@
 Tests for _assert_sample_and_rtype method
 """
 
-import numpyro
 import pytest
 from numpy.testing import assert_equal
-from pyrenew.metaclass import RandomVariable, SampledValue, _assert_sample_and_rtype
+from pyrenew.metaclass import (
+    RandomVariable,
+    SampledValue,
+    _assert_sample_and_rtype,
+)
 
 
 class RVreturnsTuple(RandomVariable):
@@ -25,7 +28,9 @@ class RVreturnsTuple(RandomVariable):
         )
         """
 
-        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
+        return (
+            SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),
+        )
 
     def validate(self):
         """
@@ -55,7 +60,9 @@ class RVnoAnnotation(RandomVariable):
         )
         """
 
-        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
+        return (
+            SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),
+        )
 
     def validate(self):
         """
@@ -68,14 +75,16 @@ class RVnoAnnotation(RandomVariable):
         return None
 
 
-def test_none_rv():
+def test_none_rv():  # numpydoc ignore=GL08
     assert_equal(_assert_sample_and_rtype(None), None)
 
-    with pytest.raises(Exception, match="None is not an instance of RandomVariable"):
+    with pytest.raises(
+        Exception, match="None is not an instance of RandomVariable"
+    ):
         _assert_sample_and_rtype(None, skip_if_none=False)
 
 
-def test_sample_return():
+def test_sample_return():  # numpydoc ignore=GL08
     """
     Test that RandomVariable has a sample method with return type tuple
     """
@@ -84,5 +93,7 @@ def test_sample_return():
     _assert_sample_and_rtype(rv1)
 
     rv2 = RVnoAnnotation()
-    with pytest.raises(Exception, match="does not have return type annotation"):
+    with pytest.raises(
+        Exception, match="does not have return type annotation"
+    ):
         _assert_sample_and_rtype(rv2)

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -103,7 +103,7 @@ def test_input_rv():  # numpydoc ignore=GL08
 
     with pytest.raises(
         Exception,
-        match=re.escape(f"{not_rv} is not an instance of RandomVariable"),
+        match="is not an instance of RandomVariable",
     ):
         _assert_sample_and_rtype(not_rv)
 
@@ -119,6 +119,6 @@ def test_sample_return():  # numpydoc ignore=GL08
     rv4 = RVnoAnnotation()
     with pytest.raises(
         Exception,
-        match=f"The RandomVariable {rv4} does not have return type annotation",
+        match="does not have return type annotation",
     ):
         _assert_sample_and_rtype(rv4)

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -28,9 +28,7 @@ class RVreturnsTuple(RandomVariable):
         )
         """
 
-        return (
-            SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),
-        )
+        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
 
     def validate(self):
         """
@@ -60,9 +58,7 @@ class RVnoAnnotation(RandomVariable):
         )
         """
 
-        return (
-            SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),
-        )
+        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
 
     def validate(self):
         """
@@ -78,10 +74,13 @@ class RVnoAnnotation(RandomVariable):
 def test_none_rv():  # numpydoc ignore=GL08
     assert_equal(_assert_sample_and_rtype(None), None)
 
-    with pytest.raises(
-        Exception, match="None is not an instance of RandomVariable"
-    ):
+    with pytest.raises(Exception, match="None is not an instance of RandomVariable"):
         _assert_sample_and_rtype(None, skip_if_none=False)
+
+
+def test_not_a_rv():  # numpydoc ignore=GL08
+    with pytest.raises(Exception, match="is not an instance of RandomVariable"):
+        _assert_sample_and_rtype(1)
 
 
 def test_sample_return():  # numpydoc ignore=GL08
@@ -93,7 +92,5 @@ def test_sample_return():  # numpydoc ignore=GL08
     _assert_sample_and_rtype(rv1)
 
     rv2 = RVnoAnnotation()
-    with pytest.raises(
-        Exception, match="does not have return type annotation"
-    ):
+    with pytest.raises(Exception, match="does not have return type annotation"):
         _assert_sample_and_rtype(rv2)

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -2,8 +2,6 @@
 Tests for _assert_sample_and_rtype method
 """
 
-import re
-
 import jax.numpy as jnp
 import numpyro.distributions as dist
 import pytest

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -1,0 +1,88 @@
+"""
+Tests for _assert_sample_and_rtype method
+"""
+
+import numpyro
+import pytest
+from numpy.testing import assert_equal
+from pyrenew.metaclass import RandomVariable, SampledValue, _assert_sample_and_rtype
+
+
+class RVreturnsTuple(RandomVariable):
+    """
+    Class for a RandomVariable with
+    sample value 1
+    """
+
+    def sample(self, **kwargs) -> tuple:
+        """
+        Deterministic sampling method that returns 1
+
+        Returns
+        -------
+        (
+        SampledValue(1, t_start=self.t_start, t_unit=self.t_unit),
+        )
+        """
+
+        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
+
+    def validate(self):
+        """
+        No validation.
+
+        Returns
+        -------
+        None
+        """
+        return None
+
+
+class RVnoAnnotation(RandomVariable):
+    """
+    Class for a RandomVariable with
+    sample value 1
+    """
+
+    def sample(self, **kwargs):
+        """
+        Deterministic sampling method that returns 1
+
+        Returns
+        -------
+        (
+        SampledValue(1, t_start=self.t_start, t_unit=self.t_unit),
+        )
+        """
+
+        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
+
+    def validate(self):
+        """
+        No validation.
+
+        Returns
+        -------
+        None
+        """
+        return None
+
+
+def test_none_rv():
+    assert_equal(_assert_sample_and_rtype(None), None)
+
+    with pytest.raises(Exception, match="None is not an instance of RandomVariable"):
+        _assert_sample_and_rtype(None, skip_if_none=False)
+
+
+def test_sample_return():
+    """
+    Test that RandomVariable has a sample method with return type tuple
+    """
+
+    rv1 = RVreturnsTuple()
+    _assert_sample_and_rtype(rv1)
+
+    rv2 = RVnoAnnotation()
+    with pytest.raises(Exception, match="does not have return type annotation"):
+        _assert_sample_and_rtype(rv2)

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -2,6 +2,8 @@
 Tests for _assert_sample_and_rtype method
 """
 
+import re
+
 import pytest
 from numpy.testing import assert_equal
 from pyrenew.metaclass import (
@@ -85,10 +87,13 @@ def test_none_rv():  # numpydoc ignore=GL08
 
 
 def test_not_a_rv():  # numpydoc ignore=GL08
+    not_rv = (1,)
+
     with pytest.raises(
-        Exception, match="is not an instance of RandomVariable"
+        Exception,
+        match=re.escape(f"{not_rv} is not an instance of RandomVariable"),
     ):
-        _assert_sample_and_rtype(1)
+        _assert_sample_and_rtype(not_rv)
 
 
 def test_sample_return():  # numpydoc ignore=GL08
@@ -101,6 +106,7 @@ def test_sample_return():  # numpydoc ignore=GL08
 
     rv2 = RVnoAnnotation()
     with pytest.raises(
-        Exception, match="does not have return type annotation"
+        Exception,
+        match=f"The RandomVariable {rv2} does not have return type annotation",
     ):
         _assert_sample_and_rtype(rv2)

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -4,9 +4,13 @@ Tests for _assert_sample_and_rtype method
 
 import re
 
+import jax.numpy as jnp
+import numpyro.distributions as dist
 import pytest
 from numpy.testing import assert_equal
+from pyrenew.deterministic import DeterministicVariable, NullObservation
 from pyrenew.metaclass import (
+    DistributionalRV,
     RandomVariable,
     SampledValue,
     _assert_sample_and_rtype,
@@ -86,8 +90,16 @@ def test_none_rv():  # numpydoc ignore=GL08
         _assert_sample_and_rtype(None, skip_if_none=False)
 
 
-def test_not_a_rv():  # numpydoc ignore=GL08
-    not_rv = (1,)
+def test_input_rv():  # numpydoc ignore=GL08
+    valid_rv = [
+        NullObservation(),
+        DeterministicVariable(name="rv1", value=jnp.array([1, 2, 3, 4])),
+        DistributionalRV(name="rv2", dist=dist.Normal(0, 1)),
+    ]
+    not_rv = jnp.array([1])
+
+    for rv in valid_rv:
+        _assert_sample_and_rtype(rv)
 
     with pytest.raises(
         Exception,
@@ -101,12 +113,12 @@ def test_sample_return():  # numpydoc ignore=GL08
     Test that RandomVariable has a sample method with return type tuple
     """
 
-    rv1 = RVreturnsTuple()
-    _assert_sample_and_rtype(rv1)
+    rv3 = RVreturnsTuple()
+    _assert_sample_and_rtype(rv3)
 
-    rv2 = RVnoAnnotation()
+    rv4 = RVnoAnnotation()
     with pytest.raises(
         Exception,
-        match=f"The RandomVariable {rv2} does not have return type annotation",
+        match=f"The RandomVariable {rv4} does not have return type annotation",
     ):
-        _assert_sample_and_rtype(rv2)
+        _assert_sample_and_rtype(rv4)

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -28,7 +28,9 @@ class RVreturnsTuple(RandomVariable):
         )
         """
 
-        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
+        return (
+            SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),
+        )
 
     def validate(self):
         """
@@ -58,7 +60,9 @@ class RVnoAnnotation(RandomVariable):
         )
         """
 
-        return (SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),)
+        return (
+            SampledValue(value=1, t_start=self.t_start, t_unit=self.t_unit),
+        )
 
     def validate(self):
         """
@@ -74,12 +78,16 @@ class RVnoAnnotation(RandomVariable):
 def test_none_rv():  # numpydoc ignore=GL08
     assert_equal(_assert_sample_and_rtype(None), None)
 
-    with pytest.raises(Exception, match="None is not an instance of RandomVariable"):
+    with pytest.raises(
+        Exception, match="None is not an instance of RandomVariable"
+    ):
         _assert_sample_and_rtype(None, skip_if_none=False)
 
 
 def test_not_a_rv():  # numpydoc ignore=GL08
-    with pytest.raises(Exception, match="is not an instance of RandomVariable"):
+    with pytest.raises(
+        Exception, match="is not an instance of RandomVariable"
+    ):
         _assert_sample_and_rtype(1)
 
 
@@ -92,5 +100,7 @@ def test_sample_return():  # numpydoc ignore=GL08
     _assert_sample_and_rtype(rv1)
 
     rv2 = RVnoAnnotation()
-    with pytest.raises(Exception, match="does not have return type annotation"):
+    with pytest.raises(
+        Exception, match="does not have return type annotation"
+    ):
         _assert_sample_and_rtype(rv2)


### PR DESCRIPTION
This PR attempts to add tests to `_assert_sample_and_rtype` function defined as
```{python}
def _assert_sample_and_rtype(
    rp: "RandomVariable", skip_if_none: bool = True
) -> None:
```
Tests included

1. return `None` if `(rp is None) and (skip_if_none)` 
2. raises error if `(rp is None) and (not skip_if_none)` 
3. check `rp` is a valid `RandomVariable`
4. check return type is a tuple and is annotated as such 
5. raises error when return type annotation is missing in sample



