### PR TITLE
move `ipywidgets` to `docs` dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 nbconvert = "^7.16.4"
-ipywidgets = "^8.1.3"
 deptry = "^0.17.0"
 
 [tool.poetry.group.docs]
@@ -41,6 +40,7 @@ sphinx = "^7.2.6"
 sphinxcontrib-mermaid = "^0.9.2"
 sphinx-autodoc-typehints = "^2.1.0"
 sphinx-book-theme = "^1.1.2"
+ipywidgets = "^8.1.3"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
Should've noticed this yesterday but I think `ipywidgets` should be in `docs` dependency to prevent warnings (see below) in the tutorials
```
/home/runner/.cache/pypoetry/virtualenvs/multisignal-epi-inference-vAaUqUWX-py3.12/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
  from .autonotebook import tqdm as notebook_tqdm
```