### PR TITLE
Explicitly specify domain for AffineTransform in ScaledLogitTransform

### DIFF
--- a/model/src/pyrenew/transformation/builtin.py
+++ b/model/src/pyrenew/transformation/builtin.py
@@ -5,6 +5,7 @@ Built-in pyrenew transformations created using `numpyro.distributions.transforms
 import numpyro.distributions.transforms as nt
 from numpyro.distributions import constraints
 
+
 def ScaledLogitTransform(
     x_max: float,
 ) -> nt.ComposeTransform:
@@ -27,8 +28,10 @@ def ScaledLogitTransform(
         - numpyro.distributions.transforms.SigmoidTransform().inv
     """
     return nt.ComposeTransform(
-        [nt.AffineTransform(
-            0.0, 1.0 / x_max, 
-            domain=constraints.interval(0, x_max)), 
-         nt.SigmoidTransform().inv]
+        [
+            nt.AffineTransform(
+                0.0, 1.0 / x_max, domain=constraints.interval(0, x_max)
+            ),
+            nt.SigmoidTransform().inv,
+        ]
     )

--- a/model/src/pyrenew/transformation/builtin.py
+++ b/model/src/pyrenew/transformation/builtin.py
@@ -29,5 +29,6 @@ def ScaledLogitTransform(
     return nt.ComposeTransform(
         [nt.AffineTransform(
             0.0, 1.0 / x_max, 
-            domain=constraints.interval(0, x_max), nt.SigmoidTransform().inv]
+            domain=constraints.interval(0, x_max)), 
+         nt.SigmoidTransform().inv]
     )

--- a/model/src/pyrenew/transformation/builtin.py
+++ b/model/src/pyrenew/transformation/builtin.py
@@ -3,7 +3,7 @@ Built-in pyrenew transformations created using `numpyro.distributions.transforms
 """
 
 import numpyro.distributions.transforms as nt
-
+from numpyro.distributions import constraints
 
 def ScaledLogitTransform(
     x_max: float,
@@ -27,5 +27,7 @@ def ScaledLogitTransform(
         - numpyro.distributions.transforms.SigmoidTransform().inv
     """
     return nt.ComposeTransform(
-        [nt.AffineTransform(0.0, 1.0 / x_max), nt.SigmoidTransform().inv]
+        [nt.AffineTransform(
+            0.0, 1.0 / x_max, 
+            domain=constraints.interval(0, x_max), nt.SigmoidTransform().inv]
     )


### PR DESCRIPTION
This will prevent bugs if it is used to create `TransformedDistribution`s See https://github.com/pyro-ppl/numpyro/issues/1756