### PR TITLE
Dynamic and static distributional rvs

### DIFF
--- a/docs/source/tutorials/basic_renewal_model.qmd
+++ b/docs/source/tutorials/basic_renewal_model.qmd
@@ -126,7 +126,7 @@ gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
 # (2) Initial infections (inferred with a prior)
 I0 = InfectionInitializationProcess(
     "I0_initialization",
-    DistributionalRV(name="I0", dist=dist.LogNormal(2.5, 1)),
+    DistributionalRV(name="I0", distribution=dist.LogNormal(2.5, 1)),
     InitializeInfectionsZeroPad(pmf_array.size),
     t_unit=1,
 )
@@ -148,12 +148,12 @@ class MyRt(RandomVariable):
                 name="log_rt",
                 step_rv=DistributionalRV(
                     name="rw_step_rv",
-                    dist=dist.Normal(0, sd_rt),
+                    distribution=dist.Normal(0, sd_rt),
                     reparam=LocScaleReparam(0),
                 ),
                 init_rv=DistributionalRV(
                     name="init_log_rt",
-                    dist=dist.Normal(jnp.log(1), jnp.log(1.2)),
+                    distribution=dist.Normal(jnp.log(1), jnp.log(1.2)),
                 ),
             ),
             transforms=t.ExpTransform(),

--- a/docs/source/tutorials/extending_pyrenew.qmd
+++ b/docs/source/tutorials/extending_pyrenew.qmd
@@ -49,7 +49,7 @@ feedback_strength = DeterministicVariable(name="feedback_strength", value=0.01)
 
 I0 = InfectionInitializationProcess(
     "I0_initialization",
-    DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+    DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
     InitializeInfectionsExponentialGrowth(
         gen_int_array.size,
         DeterministicVariable(name="rate", value=0.05),
@@ -67,9 +67,11 @@ rt = TransformedRandomVariable(
     base_rv=SimpleRandomWalkProcess(
         name="log_rt",
         step_rv=DistributionalRV(
-            name="rw_step_rv", dist=dist.Normal(0, 0.025)
+            name="rw_step_rv", distribution=dist.Normal(0, 0.025)
         ),
-        init_rv=DistributionalRV(name="init_log_rt", dist=dist.Normal(0, 0.2)),
+        init_rv=DistributionalRV(
+            name="init_log_rt", distribution=dist.Normal(0, 0.2)
+        ),
     ),
     transforms=t.ExpTransform(),
 )

--- a/docs/source/tutorials/hospital_admissions_model.qmd
+++ b/docs/source/tutorials/hospital_admissions_model.qmd
@@ -146,7 +146,7 @@ inf_hosp_int = deterministic.DeterministicPMF(
 )
 
 hosp_rate = metaclass.DistributionalRV(
-    name="IHR", dist=dist.LogNormal(jnp.log(0.05), jnp.log(1.1))
+    name="IHR", distribution=dist.LogNormal(jnp.log(0.05), jnp.log(1.1))
 )
 
 latent_hosp = latent.HospitalAdmissions(
@@ -171,7 +171,8 @@ latent_inf = latent.Infections()
 I0 = InfectionInitializationProcess(
     "I0_initialization",
     metaclass.DistributionalRV(
-        name="I0", dist=dist.LogNormal(loc=jnp.log(100), scale=jnp.log(1.75))
+        name="I0",
+        distribution=dist.LogNormal(loc=jnp.log(100), scale=jnp.log(1.75)),
     ),
     InitializeInfectionsExponentialGrowth(
         gen_int_array.size,
@@ -199,10 +200,10 @@ class MyRt(metaclass.RandomVariable):
             base_rv=process.SimpleRandomWalkProcess(
                 name="log_rt",
                 step_rv=metaclass.DistributionalRV(
-                    name="rw_step_rv", dist=dist.Normal(0, sd_rt.value)
+                    name="rw_step_rv", distribution=dist.Normal(0, sd_rt.value)
                 ),
                 init_rv=metaclass.DistributionalRV(
-                    name="init_log_rt", dist=dist.Normal(0, 0.2)
+                    name="init_log_rt", distribution=dist.Normal(0, 0.2)
                 ),
             ),
             transforms=transformation.ExpTransform(),
@@ -213,7 +214,7 @@ class MyRt(metaclass.RandomVariable):
 
 rtproc = MyRt(
     metaclass.DistributionalRV(
-        name="Rt_random_walk_sd", dist=dist.HalfNormal(0.025)
+        name="Rt_random_walk_sd", distribution=dist.HalfNormal(0.025)
     )
 )
 
@@ -225,7 +226,7 @@ nb_conc_rv = metaclass.TransformedRandomVariable(
     "concentration",
     metaclass.DistributionalRV(
         name="concentration_raw",
-        dist=dist.TruncatedNormal(loc=0, scale=1, low=0.01),
+        distribution=dist.TruncatedNormal(loc=0, scale=1, low=0.01),
     ),
     transformation.PowerTransform(-2),
 )

--- a/docs/source/tutorials/periodic_effects.qmd
+++ b/docs/source/tutorials/periodic_effects.qmd
@@ -77,7 +77,7 @@ mysimplex = dist.TransformedDistribution(
 dayofweek = process.DayOfWeekEffect(
     offset=0,
     quantity_to_broadcast=metaclass.DistributionalRV(
-        name="simp", dist=mysimplex
+        name="simp", distribution=mysimplex
     ),
     t_start=0,
 )

--- a/model/src/test/test_assert_sample_and_rtype.py
+++ b/model/src/test/test_assert_sample_and_rtype.py
@@ -92,7 +92,7 @@ def test_input_rv():  # numpydoc ignore=GL08
     valid_rv = [
         NullObservation(),
         DeterministicVariable(name="rv1", value=jnp.array([1, 2, 3, 4])),
-        DistributionalRV(name="rv2", dist=dist.Normal(0, 1)),
+        DistributionalRV(name="rv2", distribution=dist.Normal(0, 1)),
     ]
     not_rv = jnp.array([1])
 

--- a/model/src/test/test_assert_type.py
+++ b/model/src/test/test_assert_type.py
@@ -14,7 +14,7 @@ def test_valid_assertion_types():
         5,
         "Hello",
         (1,),
-        DistributionalRV(name="rv", dist=dist.Beta(1, 1)),
+        DistributionalRV(name="rv", distribution=dist.Beta(1, 1)),
     ]
     arg_names = ["input_int", "input_string", "input_tuple", "input_rv"]
     input_types = [int, str, tuple, RandomVariable]

--- a/model/src/test/test_distributional_rv.py
+++ b/model/src/test/test_distributional_rv.py
@@ -1,0 +1,107 @@
+"""
+Tests for the distributional RV classes
+"""
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+import pytest
+from numpy.testing import assert_array_equal
+from pyrenew.metaclass import (
+    DistributionalRV,
+    DynamicDistributionalRV,
+    StaticDistributionalRV,
+)
+
+
+class NonCallableTestClass:
+    """
+    Generic non-callable object to test
+    callable checking for DynamicDistributionalRV.
+    """
+
+    def __init__(self):
+        """
+        Initialization method for generic non-callable
+        object
+        """
+        pass
+
+
+@pytest.mark.parametrize("not_a_dist", [1, "test", NonCallableTestClass()])
+def test_invalid_constructor_args(not_a_dist):
+    """
+    Test that the constructor errors
+    appropriately when given incorrect input
+    """
+
+    with pytest.raises(
+        ValueError, match="distribution argument to DistributionalRV"
+    ):
+        DistributionalRV(name="this should fail", distribution=not_a_dist)
+    with pytest.raises(
+        ValueError,
+        match=(
+            "distribution should be an instance of "
+            "numpyro.distributions.Distribution"
+        ),
+    ):
+        StaticDistributionalRV.validate(not_a_dist)
+    with pytest.raises(ValueError, match="must provide a Callable"):
+        DynamicDistributionalRV.validate(not_a_dist)
+
+
+@pytest.mark.parametrize(
+    ["valid_static_dist_arg", "valid_dynamic_dist_arg"],
+    [
+        [dist.Normal(0, 1), dist.Normal],
+        [dist.Cauchy(3.0, 5.0), dist.Cauchy],
+        [dist.Poisson(0.25), dist.Poisson],
+    ],
+)
+def test_factory_triage(valid_static_dist_arg, valid_dynamic_dist_arg):
+    """
+    Test that passing a numpyro.distributions.Distribution
+    instance to the DistributionalRV factory instaniates
+    a StaticDistributionalRV, while passing a callable
+    instaniates a DynamicDistributionalRV
+    """
+    static = DistributionalRV(
+        name="test static", distribution=valid_static_dist_arg
+    )
+    assert isinstance(static, StaticDistributionalRV)
+    dynamic = DistributionalRV(
+        name="test dynamic", distribution=valid_dynamic_dist_arg
+    )
+    assert isinstance(dynamic, DynamicDistributionalRV)
+
+
+@pytest.mark.parametrize(
+    ["dist", "params"],
+    [
+        [dist.Normal, {"loc": 0.0, "scale": 0.5}],
+        [dist.Poisson, {"rate": 0.35265}],
+        [
+            dist.Cauchy,
+            {
+                "loc": jnp.array([1.0, 5.0, -0.25]),
+                "scale": jnp.array([0.02, 0.15, 2]),
+            },
+        ],
+    ],
+)
+def test_sampling_equivalent(dist, params):
+    """
+    Test that sampling a DynamicDistributionalRV
+    with a given parameterization is equivalent to
+    sampling a StaticDistributionalRV with the
+    same parameterization and the same random seed
+    """
+    static = DistributionalRV(name="static", distribution=dist(**params))
+    dynamic = DistributionalRV(name="dynamic", distribution=dist)
+    assert isinstance(static, StaticDistributionalRV)
+    assert isinstance(dynamic, DynamicDistributionalRV)
+    with numpyro.handlers.seed(rng_seed=5):
+        static_samp, *_ = static()
+    with numpyro.handlers.seed(rng_seed=5):
+        dynamic_samp, *_ = dynamic(**params)
+    assert_array_equal(static_samp.value, dynamic_samp.value)

--- a/model/src/test/test_forecast.py
+++ b/model/src/test/test_forecast.py
@@ -24,7 +24,7 @@ def test_forecast():
     gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )

--- a/model/src/test/test_infection_seeding_process.py
+++ b/model/src/test/test_infection_seeding_process.py
@@ -19,14 +19,14 @@ def test_infection_initialization_process():
 
     zero_pad_model = InfectionInitializationProcess(
         "zero_pad_model",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints),
         t_unit=1,
     )
 
     exp_model = InfectionInitializationProcess(
         "exp_model",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsExponentialGrowth(
             n_timepoints, DeterministicVariable(name="rate", value=0.5)
         ),

--- a/model/src/test/test_latent_admissions.py
+++ b/model/src/test/test_latent_admissions.py
@@ -63,7 +63,7 @@ def test_admissions_sample():
     hosp1 = HospitalAdmissions(
         infection_to_admission_interval_rv=inf_hosp,
         infect_hosp_rate_rv=DistributionalRV(
-            name="IHR", dist=dist.LogNormal(jnp.log(0.05), 0.05)
+            name="IHR", distribution=dist.LogNormal(jnp.log(0.05), 0.05)
         ),
     )
 

--- a/model/src/test/test_model_basic_renewal.py
+++ b/model/src/test/test_model_basic_renewal.py
@@ -33,7 +33,7 @@ def test_model_basicrenewal_no_timepoints_or_observations():
         name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
-    I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
+    I0 = DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1))
 
     latent_infections = Infections()
 
@@ -64,7 +64,7 @@ def test_model_basicrenewal_both_timepoints_and_observations():
         value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
-    I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
+    I0 = DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1))
 
     latent_infections = Infections()
 
@@ -100,11 +100,11 @@ def test_model_basicrenewal_no_obs_model():
     )
 
     with pytest.raises(ValueError):
-        I0 = DistributionalRV(name="I0", dist=1)
+        I0 = DistributionalRV(name="I0", distribution=1)
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )
@@ -175,7 +175,7 @@ def test_model_basicrenewal_with_obs_model():
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )
@@ -224,7 +224,7 @@ def test_model_basicrenewal_padding() -> None:  # numpydoc ignore=GL08
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )

--- a/model/src/test/test_model_hosp_admissions.py
+++ b/model/src/test/test_model_hosp_admissions.py
@@ -57,7 +57,7 @@ def test_model_hosp_no_timepoints_or_observations():
         name="gen_int", value=jnp.array([0.25, 0.25, 0.25, 0.25])
     )
 
-    I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
+    I0 = DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1))
 
     latent_infections = Infections()
     Rt_process = simple_rt()
@@ -93,7 +93,7 @@ def test_model_hosp_no_timepoints_or_observations():
     latent_admissions = HospitalAdmissions(
         infection_to_admission_interval_rv=inf_hosp,
         infect_hosp_rate_rv=DistributionalRV(
-            name="IHR", dist=dist.LogNormal(jnp.log(0.05), 0.05)
+            name="IHR", distribution=dist.LogNormal(jnp.log(0.05), 0.05)
         ),
     )
 
@@ -122,7 +122,7 @@ def test_model_hosp_both_timepoints_and_observations():
         value=jnp.array([0.25, 0.25, 0.25, 0.25]),
     )
 
-    I0 = DistributionalRV(name="I0", dist=dist.LogNormal(0, 1))
+    I0 = DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1))
 
     latent_infections = Infections()
     Rt_process = simple_rt()
@@ -158,7 +158,7 @@ def test_model_hosp_both_timepoints_and_observations():
     latent_admissions = HospitalAdmissions(
         infection_to_admission_interval_rv=inf_hosp,
         infect_hosp_rate_rv=DistributionalRV(
-            name="IHR", dist=dist.LogNormal(jnp.log(0.05), 0.05)
+            name="IHR", distribution=dist.LogNormal(jnp.log(0.05), 0.05)
         ),
     )
 
@@ -192,7 +192,7 @@ def test_model_hosp_no_obs_model():
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )
@@ -230,7 +230,7 @@ def test_model_hosp_no_obs_model():
         infection_to_admission_interval_rv=inf_hosp,
         infect_hosp_rate_rv=DistributionalRV(
             name="IHR",
-            dist=dist.LogNormal(jnp.log(0.05), 0.05),
+            distribution=dist.LogNormal(jnp.log(0.05), 0.05),
         ),
     )
 
@@ -302,7 +302,7 @@ def test_model_hosp_with_obs_model():
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )
@@ -341,7 +341,7 @@ def test_model_hosp_with_obs_model():
         infection_to_admission_interval_rv=inf_hosp,
         infect_hosp_rate_rv=DistributionalRV(
             name="IHR",
-            dist=dist.LogNormal(jnp.log(0.05), 0.05),
+            distribution=dist.LogNormal(jnp.log(0.05), 0.05),
         ),
     )
 
@@ -389,7 +389,7 @@ def test_model_hosp_with_obs_model_weekday_phosp_2():
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )
@@ -438,7 +438,7 @@ def test_model_hosp_with_obs_model_weekday_phosp_2():
         day_of_week_effect_rv=weekday,
         hosp_report_prob_rv=hosp_report_prob_dist,
         infect_hosp_rate_rv=DistributionalRV(
-            name="IHR", dist=dist.LogNormal(jnp.log(0.05), 0.05)
+            name="IHR", distribution=dist.LogNormal(jnp.log(0.05), 0.05)
         ),
     )
 
@@ -488,7 +488,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
 
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )
@@ -549,7 +549,7 @@ def test_model_hosp_with_obs_model_weekday_phosp():
         hosp_report_prob_rv=hosp_report_prob_dist,
         infect_hosp_rate_rv=DistributionalRV(
             name="IHR",
-            dist=dist.LogNormal(jnp.log(0.05), 0.05),
+            distribution=dist.LogNormal(jnp.log(0.05), 0.05),
         ),
     )
 

--- a/model/src/test/test_predictive.py
+++ b/model/src/test/test_predictive.py
@@ -23,7 +23,7 @@ pmf_array = jnp.array([0.25, 0.1, 0.2, 0.45])
 gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
 I0 = InfectionInitializationProcess(
     "I0_initialization",
-    DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+    DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
     InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
     t_unit=1,
 )

--- a/model/src/test/test_random_key.py
+++ b/model/src/test/test_random_key.py
@@ -28,7 +28,7 @@ def create_test_model():  # numpydoc ignore=GL08
     gen_int = DeterministicPMF(name="gen_int", value=pmf_array)
     I0 = InfectionInitializationProcess(
         "I0_initialization",
-        DistributionalRV(name="I0", dist=dist.LogNormal(0, 1)),
+        DistributionalRV(name="I0", distribution=dist.LogNormal(0, 1)),
         InitializeInfectionsZeroPad(n_timepoints=gen_int.size()),
         t_unit=1,
     )

--- a/model/src/test/test_random_walk.py
+++ b/model/src/test/test_random_walk.py
@@ -16,13 +16,13 @@ def test_rw_can_be_sampled():
     """
     init_rv_rand = DistributionalRV(
         name="init_rv_rand",
-        dist=dist.Normal(1, 0.5),
+        distribution=dist.Normal(1, 0.5),
     )
     init_rv_fixed = DeterministicVariable(name="init_rv_fixed", value=50.0)
 
     step_rv = DistributionalRV(
         name="rw_step",
-        dist=dist.Normal(0, 1),
+        distribution=dist.Normal(0, 1),
     )
 
     rw_init_rand = SimpleRandomWalkProcess(
@@ -63,7 +63,7 @@ def test_rw_samples_correctly_distributed():
             name="rw_normal_test",
             step_rv=DistributionalRV(
                 name="rw_normal_dist",
-                dist=dist.Normal(loc=step_mean, scale=step_sd),
+                distribution=dist.Normal(loc=step_mean, scale=step_sd),
             ),
             init_rv=DeterministicVariable(
                 name="init_rv_fixed", value=rw_init_val

--- a/model/src/test/test_transformed_rv_class.py
+++ b/model/src/test/test_transformed_rv_class.py
@@ -67,7 +67,9 @@ def test_transform_rv_validation():
     works as expected.
     """
 
-    base_rv = DistributionalRV(name="test_normal", dist=dist.Normal(0, 1))
+    base_rv = DistributionalRV(
+        name="test_normal", distribution=dist.Normal(0, 1)
+    )
     base_rv.sample_length = lambda: 1  # numpydoc ignore=GL08
 
     l2_rv = LengthTwoRV()
@@ -109,7 +111,9 @@ def test_transforms_applied_at_sampling():
     instances correctly apply their specified
     transformations at sampling
     """
-    norm_rv = DistributionalRV(name="test_normal", dist=dist.Normal(0, 1))
+    norm_rv = DistributionalRV(
+        name="test_normal", distribution=dist.Normal(0, 1)
+    )
     norm_rv.sample_length = lambda: 1
 
     l2_rv = LengthTwoRV()

--- a/model/src/test/utils.py
+++ b/model/src/test/utils.py
@@ -32,10 +32,10 @@ def simple_rt(arg_name: str = "Rt_rv"):
         base_rv=SimpleRandomWalkProcess(
             name="log_rt",
             step_rv=DistributionalRV(
-                name="rw_step_rv", dist=dist.Normal(0, 0.025)
+                name="rw_step_rv", distribution=dist.Normal(0, 0.025)
             ),
             init_rv=DistributionalRV(
-                name="init_log_rt", dist=dist.Normal(0, 0.2)
+                name="init_log_rt", distribution=dist.Normal(0, 0.2)
             ),
         ),
         transforms=t.ExpTransform(),


### PR DESCRIPTION
This separates `DistributionalRV` into `StaticDistributionalRV`, in which the distribution is already instantiated (has fixed parameter values) and `DynamicDistributionalRV`, in which the distribution is instantiated when `sample()` is called with keyword arguments taken from the `sample()` call. The latter is designed to serve as a wrapper class for working with distributions with inferred parameters.

It also 
- Renames the `dist` keyword arg to `DistributionalRV` to `distribution`, to avoid clashes given the standard `numpyro` pattern of `import numpyro.distributions as dist`. 
- adds some basic tests for both subclasses